### PR TITLE
Palette and clock changes

### DIFF
--- a/SRC/GRAPHICS.CPP
+++ b/SRC/GRAPHICS.CPP
@@ -7,6 +7,4 @@ void setpal(char palette[768], int brightness)
     // Since setpal() is expected to update VGA registers and thus refresh the screen,
     // should be an okay place to tick (which also does present).
     tk_port_event_tick();
-    // "The VGA refreshes the screen 70 times a second, or 70hz". http://www.brackeen.com/vga/bitmaps.html#7
-    tk_port_sleep(1000 / 70);
 }

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -11,16 +11,12 @@ static SDL_Palette *palette;
 bool tk_port_quit_flag = false;
 uint32_t tk_port_debug = 0;
 
-#ifdef TK_PORT_POSIX
-static struct timespec timer_zero;
-#endif
+static uint64_t timer_zero;
+#define TK_PORT_NSEC_PER_SEC 1000000000L
+
 #ifdef TK_PORT_MAC
-
 #include <mach/mach_time.h>
-
 static mach_timebase_info_data_t timer_timebase_info;
-static uint64_t timer_zero = 0;
-
 #endif
 
 static Uint32 tk_port_update_framecount( Uint32 interval, void *param )
@@ -95,7 +91,9 @@ static void tk_port_init_time()
     SDL_AddTimer( 1000 / target_frames, tk_port_update_framecount, NULL );
 
 #ifdef TK_PORT_POSIX
-    clock_gettime(CLOCK_MONOTONIC, &timer_zero);
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    timer_zero = tv.tv_sec * TK_PORT_NSEC_PER_SEC + tv.tv_nsec;
 #endif
 #ifdef TK_PORT_MAC
     mach_timebase_info( &timer_timebase_info );
@@ -268,18 +266,15 @@ void tk_port_sleep( int msec )
  * A clock that returns wallclock values in "vintage time", which are arbitrary ticks.
  * @return integer describing the current time.
  */
-#define TK_PORT_NSEC_PER_SEC 1000000000L
-
 static uint64_t tk_port_nanoclock()
 {
 #if defined(TK_PORT_MAC)
     uint64_t now = mach_absolute_time();
     return (now - timer_zero) * timer_timebase_info.numer / timer_timebase_info.denom;
 #elif defined(TK_PORT_POSIX)
-    // TODO: This code is untested!
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
-    return ( now.tv_sec - timer_zero.tv_sec ) * TK_PORT_NSEC_PER_SEC + ( now.tv_nsec - timer_zero.tv_nsec );
+    return (now.tv_sec * TK_PORT_NSEC_PER_SEC + now.tv_nsec) - timer_zero;
 #else
 #error No nanoclock
 #endif

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -241,12 +241,16 @@ static int clamp( int val, int min, int max )
 void tk_port_set_palette( char palette_entries[768], int brightness )
 {
     char *palette_ptr = palette_entries;
+
+    // Adjust palette by the sine of brightness
+    double brightness_factor = sin(brightness * pi / 2 / 255);
+
     for ( int i = 0; i < 256; i++ )
     {
         // The left-shifts below scale the assumedly 0..63 VGA palette
         // (ref. http://joco.homeserver.hu/vgalessons/lesson6.html)
         // up to the 0..255 expected by SDL.
-#define DARKEN( c ) clamp(((int)(c) - 255 + brightness), 0, 255)
+#define DARKEN( c ) clamp((int)(c * brightness_factor), 0, 255)
         palette->colors[i].r = (uint8_t) clamp( DARKEN( *(palette_ptr++)) << 2, 0, 255 );
         palette->colors[i].g = (uint8_t) clamp( DARKEN( *(palette_ptr++)) << 2, 0, 255 );
         palette->colors[i].b = (uint8_t) clamp( DARKEN( *(palette_ptr++)) << 2, 0, 255 );

--- a/SRC/PORT.H
+++ b/SRC/PORT.H
@@ -5,7 +5,7 @@
 
 // openwatcom (https://github.com/open-watcom/owp4v1copy/blob/master/bld/hdr/watcom/time.mh#L94)
 // defines it as 1000.
-#define VINTAGE_CLOCKS_PER_SEC 1000
+#define VINTAGE_CLOCKS_PER_SEC 22
 
 #if defined (__APPLE__) && defined (__MACH__)
 #define TK_PORT_MAC


### PR DESCRIPTION
Adjust palette brightness by the sine of brigthness instead of linearly. This makes the menu wobbling animation look like the original one.

Fix `tk_port_nanoclock()` implementation on Linux. Just work with nanoseconds from the beginning.

Adjust `VINTAGE_CLOCKS_PER_SEC`. The value of `22` seems to more or less match the experience of the original game on DosBox.