### PR TITLE
Fix buffer overflow in statistics page.

### DIFF
--- a/SRC/I_FUNCS.H
+++ b/SRC/I_FUNCS.H
@@ -36,8 +36,13 @@ void level_info()
 
 void statics()
 {
-    char text[20], text2[20];
+    char text[32], text2[20];
     int a, b, timebonus;
+    auto get_text_buffer_left = [&text]()
+    {
+        return sizeof( text ) - strlen( text ) - 1;
+    };
+
     load_efp( "EFPS/COOL.EFP", picture, 0 );
     load_efp_pal( "EFPS/WARE.EFP", pal );
     draw_box1( 10, 10, 310, 32, 10 );
@@ -55,46 +60,46 @@ void statics()
     if ( aplayer[0]->kills[a] > 0 ) b = 1;
     if ( b == 1 )
     {
-        strcpy( text, "Kills for " );
+        strncpy( text, "Kills for ", sizeof( text ) );
     }
     if ( b == 0 )
     {
-        strcpy( text, "No kills for " );
+        strncpy( text, "No kills for ", sizeof( text ) );
     }
-    strcat( text, aplayer[0]->name );
+    strncat( text, aplayer[0]->name, get_text_buffer_left() );
     writefonts( 16, 50, text, M_YELLOW );
     for ( a = 0, b = 65; a < DIFF_ENEMIES; a ++  )
     if ( aplayer[0]->kills[a] > 0 )
     {
         aplayer[0]->total_kills += aplayer[0]->kills[a];
         sprintf( text, "%d", aplayer[0]->kills[a] );
-        strcat( text, " " );
-        strcat( text, enemy_info[a].name );
+        strncat( text, " ", get_text_buffer_left());
+        strncat( text, enemy_info[a].name, get_text_buffer_left() );
         if ( aplayer[0]->kills[a] > 1 )
-        strcat( text, "s" );
+        strncat( text, "s", get_text_buffer_left() );
         writefonts( 16, b, text, M_YELLOW );
-        strcpy( text, "+" );
-        sprintf( text2, "%d", enemy_info[a].reward*aplayer[0]->kills[a] );
+        strncpy( text, "+", sizeof( text ) );
+        snprintf( text2, sizeof( text ), "%d", enemy_info[a].reward*aplayer[0]->kills[a] );
         aplayer[0]->cash += enemy_info[a].reward*aplayer[0]->kills[a];
-        strcat( text, text2 );
+        strncat( text, text2, get_text_buffer_left() );
         writefonts( 103, b, text, M_RED );
         b += 8;
     }
     aplayer[0]->cash += timebonus;
     if ( aplayer[0]->cash < 0 ) aplayer[0]->cash = 0;
     writefonts( 16, 130, "Total kills:", M_RED );
-    sprintf( text, "%d", aplayer[0]->total_kills );
+    snprintf( text, sizeof( text ), "%d", aplayer[0]->total_kills );
     writefonts( 76, 130, text, M_YELLOW );
     writefonts( 16, 140, "Accuracy:", M_RED );
     if ( aplayer[0]->shooted > 0 )
     {
-        sprintf( text, "%d", (int) (((float) aplayer[0]->hitten / aplayer[0]->shooted) * 100));
+        snprintf( text, sizeof( text ), "%d", (int) (((float) aplayer[0]->hitten / aplayer[0]->shooted) * 100));
     }
-    else strcpy( text, "0" );
-    strcat( text, "%" );
+    else strncpy( text, "0", sizeof( text ) );
+    strncat( text, "%", get_text_buffer_left() );
     writefonts( 76, 140, text, M_YELLOW );
     writefonts( 16, 150, "Cash:", M_RED );
-    sprintf( text, "%d", aplayer[0]->cash );
+    snprintf( text, sizeof( text ), "%d", aplayer[0]->cash );
     writefonts( 76, 150, text, M_YELLOW );
     if ( GAME_MODE == SPLIT_SCREEN )
     {
@@ -102,46 +107,46 @@ void statics()
         if ( aplayer[1]->kills[a] > 0 ) b = 1;
         if ( b == 1 )
         {
-            strcpy( text, "Kills for " );
+            strncpy( text, "Kills for ", sizeof( text ) );
         }
         if ( b == 0 )
         {
-            strcpy( text, "No kills for " );
+            strncpy( text, "No kills for ", sizeof( text ) );
         }
-        strcat( text, aplayer[1]->name );
+        strncat( text, aplayer[1]->name, get_text_buffer_left() );
         writefonts( 16 + 160, 50, text, M_YELLOW );
         for ( a = 0, b = 65; a < DIFF_ENEMIES; a ++  )
         if ( aplayer[1]->kills[a] > 0 )
         {
             aplayer[1]->total_kills += aplayer[1]->kills[a];
-            sprintf( text, "%d", aplayer[1]->kills[a] );
-            strcat( text, " " );
-            strcat( text, enemy_info[a].name );
+            snprintf( text, sizeof( text ), "%d", aplayer[1]->kills[a] );
+            strncat( text, " ", get_text_buffer_left() );
+            strncat( text, enemy_info[a].name, get_text_buffer_left() ) ;
             if ( aplayer[1]->kills[a] > 1 )
-            strcat( text, "s" );
+            strncat( text, "s", get_text_buffer_left() );
             writefonts( 16 + 160, b, text, M_YELLOW );
-            strcpy( text, "+" );
-            sprintf( text2, "%d", enemy_info[a].reward*aplayer[1]->kills[a] );
+            strncpy( text, "+", sizeof( text ) );
+            snprintf( text2, sizeof( text ), "%d", enemy_info[a].reward*aplayer[1]->kills[a] );
             aplayer[1]->cash += enemy_info[a].reward*aplayer[1]->kills[a];
-            strcat( text, text2 );
+            strncat( text, text2, get_text_buffer_left() );
             writefonts( 103 + 160, b, text, M_RED );
             b += 8;
         }
         aplayer[1]->cash += timebonus;
         if ( aplayer[1]->cash < 0 ) aplayer[1]->cash = 0;
         writefonts( 16 + 160, 130, "Total kills:", M_RED );
-        sprintf( text, "%d", aplayer[1]->total_kills );
+        snprintf( text, sizeof( text ), "%d", aplayer[1]->total_kills );
         writefonts( 76 + 160, 130, text, M_YELLOW );
         writefonts( 16 + 160, 140, "Accuracy:", M_RED );
         if ( aplayer[1]->shooted > 0 )
         {
-            sprintf( text, "%d", (int) (((float) aplayer[1]->hitten / aplayer[1]->shooted) * 100));
+            snprintf( text, sizeof( text ), "%d", (int) (((float) aplayer[1]->hitten / aplayer[1]->shooted) * 100));
         }
-        else strcpy( text, "0" );
-        strcat( text, "%" );
+        else strncpy( text, "0", sizeof( text ) );
+        strncat( text, "%", get_text_buffer_left() );
         writefonts( 76 + 160, 140, text, M_YELLOW );
         writefonts( 16 + 160, 150, "Cash:", M_RED );
-        sprintf( text, "%d", aplayer[1]->cash );
+        snprintf( text, sizeof( text ), "%d", aplayer[1]->cash );
         writefonts( 76 + 160, 150, text, M_YELLOW );
     }
     writefonts( 16, 170, "Time limit:", M_RED );
@@ -149,7 +154,7 @@ void statics()
     writefonts( 16 + 80, 170, "Your time:", M_RED );
     writefonts( 16 + 80 + 55, 170, c_2_c( complete_time ), M_BLUE );
     writefonts( 16 + 80 + 80, 170, "Time bonus:", M_RED );
-    sprintf( text, "%d", timebonus );
+    snprintf( text, sizeof( text ), "%d", timebonus );
     writefonts( 16 + 80 + 55 + 80, 170, text, M_YELLOW );
     fadein( virbuff, pal );
     k.clear_stack();


### PR DESCRIPTION
If user had longer than 6 char name (game allows 9) and had no kills, text buffer overflowed (e.g. "No kills for veikkos" incl. termination is longer than the allocated 20 characters for `text` variable).

Increase buffer size and use buffer overflow protected functions.
