### PR TITLE
Add GCC 8 to Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,18 @@ matrix:
     - os: linux
       compiler: gcc
     - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+      before_install:
+        - CC=gcc-8 && CXX=g++-8
+    - os: linux
       compiler: clang
     - os: osx
       compiler: clang


### PR DESCRIPTION
Apparently Travis doesn't combine "common" packages (below) and explicitly set (`g++8` here). Hence repeating the SDL packages.

Adding GCC 8 because Net PR revealed that even if other compilers were happy in that case, GCC 8 wasn't and now we'll notice it automatically in the future.