### PR TITLE
Add missing libsdl2-net-dev to Travis CI's GCC 8 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
             - g++-8
             - libsdl2-dev
             - libsdl2-mixer-dev
+            - libsdl2-net-dev
       before_install:
         - CC=gcc-8 && CXX=g++-8
     - os: linux


### PR DESCRIPTION
Net code and GCC 8 PR's were done in parallel so net library was missing from #44 .