### PR TITLE
Buffer incoming network data to split game packets correctly

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2424,18 +2424,27 @@ void game()
                     }
                     framecount = 0;// incremented by MIDAS timer
                     game_shit();// do the game !!!!
-                    if (GAME_MODE==NETWORK && NETWORK_MODE==SERVER)
-                     chk_for_loosers();
                     Steam_count ++;
                     Steam_count%= 360;
                     Spot_count += 2;
                     Spot_count%= 360;
                     frame_count ++;
-                }
-                if ( GAME_MODE == NETWORK)
-                {
-                    if (NETWORK_MODE == CLIENT ) do_client_shit();
-                    if (NETWORK_MODE == SERVER ) do_server_shit();
+
+                    if ( GAME_MODE == NETWORK )
+                    {
+                        switch ( NETWORK_MODE )
+                        {
+                        case CLIENT:
+                            do_client_shit();
+                            break;
+                        case SERVER:
+                            chk_for_loosers();
+                            do_server_shit();
+                            break;
+                        default:
+                            error( "Invalid network mode" );
+                        }
+                    }
                 }
                 tk_port_event_tick();
             }  // game loop end

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -1392,6 +1392,9 @@ void desetup_ipx()
     flushipx();
     if ((GAME_MODE==NETWORK)&&(NETWORK_MODE==SERVER))
         sendipxnow(&n,IPX_SERVERSHUTDOWN);
+    // Wait a while before closing sockets so that
+    // clients have time to react to SERVERSHUTDOWN
+    tk_port_sleep(50);
     Net::close_connections();
 }
 
@@ -1437,7 +1440,7 @@ void do_server_shit()
     Net::accept_connections();
 
     for ( a = 0; a < RECEIVERS; a ++  )
-    if ( Net::receive(rec[a], a) )
+    if ( Net::receive(rec[a]) )
     {
         data =  - 1;
         ofs = 0;
@@ -1711,7 +1714,7 @@ void do_client_shit()
     int pl;
 
     for ( a = 0; a < RECEIVERS; a ++  )
-    if ( Net::receive(rec[a], a) )
+    if ( Net::receive(rec[a]) )
     {
         data =  - 1;
         ofs = 0;
@@ -1886,7 +1889,7 @@ int realjoin()
         {
             if (k.state[1]) return 0;
             for ( a = 0; a < RECEIVERS; a ++  )
-            if ( Net::receive(rec[a], a) )
+            if ( Net::receive(rec[a]) )
             {
                 data =  - 1;
                 ofs = 0;
@@ -1905,7 +1908,7 @@ int realjoin()
                         }
                         if (!aplayer[0]->enabled) message_board.add_message((char*)"realjoin: something missing...");
                         received=1;
-                        if (rec[a]->data[ofs+1]!=IPX_END) error("realjoin: IPX packet mismatching!");
+                        if (rec[a]->data[ofs]!=IPX_END) error("realjoin: IPX packet mismatching!");
 
                         break;
                         default:ofs+=IPXMSGLEN[data]-1;
@@ -1944,7 +1947,7 @@ int getlevel()
         {
             if (k.state[1]) return 0;
             for ( a = 0; a < RECEIVERS; a ++  )
-            if ( Net::receive(rec[a], a) )
+            if ( Net::receive(rec[a]) )
             {
                 data =  - 1;
                 ofs = 0;
@@ -1990,7 +1993,7 @@ int getlevelinfo()
         {
             if (k.state[1]) return 0;
             for ( a = 0; a < RECEIVERS; a ++  )
-            if ( Net::receive(rec[a], a) )
+            if ( Net::receive(rec[a]) )
             {
                 data =  - 1;
                 ofs = 0;
@@ -2061,7 +2064,7 @@ int waitfor(int msg,int secs)
     while ((!timeout)&&(yes!=0))
     {
         for ( a = 0; a < RECEIVERS; a ++  )
-        if ( Net::receive(rec[a], a) )
+        if ( Net::receive(rec[a]) )
         {
             data =  - 1;
             ofs = 0;
@@ -2167,7 +2170,7 @@ int select_server()
         sendipxnow(&bc,IPX_SERVERSEARCH);
 
         for ( a = 0; a < RECEIVERS; a ++  )
-        if ( Net::receive(rec[a], a) )
+        if ( Net::receive(rec[a]) )
         {
             data =  - 1;
             ofs = 0;
@@ -2424,11 +2427,6 @@ void game()
                     }
                     framecount = 0;// incremented by MIDAS timer
                     game_shit();// do the game !!!!
-                    Steam_count ++;
-                    Steam_count%= 360;
-                    Spot_count += 2;
-                    Spot_count%= 360;
-                    frame_count ++;
 
                     if ( GAME_MODE == NETWORK )
                     {
@@ -2445,6 +2443,12 @@ void game()
                             error( "Invalid network mode" );
                         }
                     }
+
+                    Steam_count ++;
+                    Steam_count%= 360;
+                    Spot_count += 2;
+                    Spot_count%= 360;
+                    frame_count ++;
                 }
                 tk_port_event_tick();
             }  // game loop end

--- a/SRC/NET/NET.CPP
+++ b/SRC/NET/NET.CPP
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "NET.H"
+#include "../ERROR/ERROR.H"
 #include "NETDEFS.H"
 #include "DEFINES.H"
 #include "SDL_net.h"
@@ -11,9 +12,18 @@
 #include <iterator>
 #include <vector>
 
-TCPsocket server_socket;
-SDLNet_SocketSet set;
-std::vector<TCPsocket> sockets(MAX_PLAYERS, nullptr);
+
+namespace
+{
+static TCPsocket server_socket;
+static SDLNet_SocketSet set;
+static std::vector<TCPsocket> sockets(MAX_PLAYERS, nullptr);
+static std::vector<std::vector<char>> socket_storages(MAX_PLAYERS);
+
+static const int PACKET_HEADER_SIZE = 2; // 2 length bytes (16-bit) at the beginning
+static const int PACKET_CHECKSUM_SIZE = 1; // 1 checksum byte at the and
+static const int PACKET_OVERHEAD_SIZE = PACKET_HEADER_SIZE + PACKET_CHECKSUM_SIZE;
+}
 
 namespace Net
 {
@@ -112,6 +122,11 @@ void close_connections()
     }
 
     std::fill(sockets.begin(), sockets.end(), nullptr);
+
+    for (auto& storage : socket_storages)
+    {
+        storage.clear();
+    }
 }
 
 void accept_connections()
@@ -138,25 +153,61 @@ void accept_connections()
 static void disconnect(const unsigned int index)
 {
     // Disconnect is not propagated up but server
-    // relies on IPX_ALIVE keep-alive messages. It
+    // relies on ALIVE keep-alive messages. It
     // then propagates disconnects to clients with
     // PLAYERDISCONNECTED message.
     SDLNet_TCP_DelSocket(set, sockets[index]);
     sockets[index] = nullptr;
+    socket_storages[index].clear();
 }
 
-bool receive(struct packet *buffer, const unsigned int index)
+// Very simple checksum for packet sanity check
+static char checksum(const char* data, word len)
 {
-    if (index >= sockets.size() || sockets[index] == nullptr) return false;
+    char c = (char)0xAA;
+    for (int i = 0; i < len; ++i)
+    {
+        c ^= data[i];
+    }
+    return c;
+}
+
+static std::vector<char> get_packet_envelope(const char* data, word len)
+{
+    std::vector<char> packet;
+    packet.push_back((char)(len >> 8));
+    packet.push_back((char)(len));
+    for (int i = 0; i < len; ++i)
+    {
+        packet.push_back(data[i]);
+    }
+    packet.push_back(checksum(data, len));
+    return packet;
+}
+
+static int get_payload_length(const char* data)
+{
+    return ((int)data[0] << 8) + (data[1] & 0xFF);
+}
+
+static void receive_to_storage(const unsigned int index)
+{
+    if (index >= sockets.size() || sockets[index] == nullptr) return;
 
     if (SDLNet_CheckSockets(set, 0))
     {
         if (SDLNet_SocketReady(sockets[index]))
         {
-            if (SDLNet_TCP_Recv(sockets[index], buffer->data, MAXDATASIZE))
+            char data[MAXDATASIZE + PACKET_OVERHEAD_SIZE];
+            const int len = SDLNet_TCP_Recv(sockets[index], data, MAXDATASIZE);
+
+            if (len)
             {
-                buffer->header.src.node = index;
-                return true;
+                auto& buffer = socket_storages[index];
+                for (int i = 0; i < len; ++i)
+                {
+                    buffer.push_back(data[i]);
+                }
             }
             else
             {
@@ -164,8 +215,76 @@ bool receive(struct packet *buffer, const unsigned int index)
             }
         }
     }
+}
+
+static bool find_next_packet_from_storage(struct packet *buffer)
+{
+    // Clients always have just one socket to server
+    for (unsigned int i = 0; i < (server_socket ? socket_storages.size() : 1); ++i)
+    {
+        auto& storage = socket_storages[i];
+
+        // Check if there is enough data for packet consisting
+        // of 1 or more payload bytes
+        if (storage.size() >= PACKET_OVERHEAD_SIZE + 1)
+        {
+            const unsigned int payload_length = get_payload_length(storage.data());
+
+            if (storage.size() < payload_length + PACKET_OVERHEAD_SIZE)
+            {
+                // Not enough data in the storage, i.e. packet not yet fully received
+                continue;
+            }
+
+            const char received_checksum = storage.data()[PACKET_HEADER_SIZE + payload_length];
+            const char calculated_checksum = checksum(storage.data() + PACKET_HEADER_SIZE, payload_length);
+
+            if (received_checksum == calculated_checksum)
+            {
+                // Packet fully received, return it to the app
+                memcpy(buffer->data, storage.data() + PACKET_HEADER_SIZE, payload_length);
+                buffer->header.src.node = i;
+
+                // Remove packet from storage
+                storage.erase(storage.begin(), storage.begin() + payload_length + PACKET_OVERHEAD_SIZE);
+
+                return true;
+            }
+            else
+            {
+                warn( "Corrupted packet\n" );
+                storage.clear();
+            }
+        }
+    }
 
     return false;
+}
+
+static unsigned int get_next_socket_to_receive()
+{
+    if (server_socket)
+    {
+        static unsigned int socket_index = 0;
+        // Loops 0 to MAX_PLAYERS - 1
+        return socket_index++ % MAX_PLAYERS;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+bool receive(struct packet *buffer)
+{
+    // Receive data evenly from sockets and store any received
+    // data to storage
+    receive_to_storage(get_next_socket_to_receive());
+
+    // Look through the socket storages to see if there are
+    // any fully received packets. Return one if finding
+    // any.
+    return find_next_packet_from_storage(buffer);
 }
 
 struct nodeaddr BROADCAST()
@@ -176,19 +295,25 @@ struct nodeaddr BROADCAST()
 void sendpacket(struct nodeaddr destnode, struct packet *packetet, word len)
 {
     const int datalength = len - 1;
+    auto packet = get_packet_envelope(packetet->data, datalength);
+
     if (destnode.node == BROADCAST_ID)
     {
-        for (auto socket : sockets)
+        for (unsigned int i = 0; i < sockets.size(); ++i)
         {
+            auto& socket = sockets[i];
             if (socket != nullptr)
             {
-                SDLNet_TCP_Send(socket, packetet->data, datalength);
+                if (SDLNet_TCP_Send(socket, packet.data(), packet.size()) != packet.size())
+                {
+                    disconnect(i);
+                }
             }
         }
     }
     else if (sockets[destnode.node] != nullptr)
     {
-        if (SDLNet_TCP_Send(sockets[destnode.node], packetet->data, datalength) != datalength)
+        if (SDLNet_TCP_Send(sockets[destnode.node], packet.data(), packet.size()) != packet.size())
         {
             disconnect(destnode.node);
         }

--- a/SRC/NET/NET.H
+++ b/SRC/NET/NET.H
@@ -1,7 +1,7 @@
 #ifndef __NET_H__
 #define __NET_H__
 
-#define RECEIVERS MAX_PLAYERS
+#define RECEIVERS 16 // Defines how many packets can be handled during a frame
 #define MAXDATASIZE 1024
 #define BROADCAST_ID 0xFF
 
@@ -36,7 +36,7 @@ void close_connections();
 
 void accept_connections();
 
-bool receive(struct packet *buffer, const unsigned int index);
+bool receive(struct packet *buffer);
 void sendpacket(struct nodeaddr destnode, struct packet *packetet, word len);
 
 struct nodeaddr BROADCAST();


### PR DESCRIPTION
- Normalize and synchronize network refresh rate to other game logic (refresh rate).
  - Network code speed was almost unlimited causing excessive package amounts.
- Implement packet envelope and proper buffers to stop packet loss.
  - Now TK code will always receive just one packet at a time. Before it might have received several combined packets but it only processes the first one causing data loss.
  - Decouple receiver indexes from socket indexes. Allows handling more than one packet per socket per frame.
- Fix use of uninitialized buffer value in realjoin. IPX_END was looked from one byte too far in the buffer and just sometimes happens to be corret value of 0.
- When closing the server, wait for a while before closing socket to allow clients to process DISCONNECT event. Not very pretty but seems effective enough. 