### PR TITLE
Readme improvements for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Build requirements
 - C++ compiler: At least gcc, clang and Visual Studio are supported
 - Libraries: SDL2, SDL2_mixer, SDL2_net 
   - On macOS, you can install these with Homebrew. `brew install sdl2 sdl2_mixer sdl2_net`
+  - On Windows you can download these from SDL website
 
 
 Building and running
@@ -30,8 +31,11 @@ make
 ```
 
 On Windows, you may need to explicitly specify paths to your SDL libraries, like
+```shell
+cmake -DSDL2_PATH="C:\\<path>\\SDL2-2.0.9" -DSDL2_MIXER_PATH="C:\\<path>\\SDL2_mixer-2.0.4" -DSDL2_NET_PATH="C:\\<path>\\SDL2_net-2.0.1" .
+```
+which produced project files for 32-bit target. For 64-bit target, use e.g. `cmake -G "Visual Studio 15 2017 Win64"`.
 
-> `cmake -DSDL2_PATH="C:\\<path>\\SDL2-2.0.9" -DSDL2_MIXER_PATH="C:\\<path>\\SDL2_mixer-2.0.4" .`
 
 
 [suomipelit-gh]: https://github.com/suomipelit


### PR DESCRIPTION
Add x64-bit build instructions.
Add missing sdl2_net from cmake command.
Add instruction where to download SDL.