### PR TITLE
Fix enemies in split screen co-op mode.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -930,8 +930,10 @@ void game_shit()
     for ( a = 0; a < ACTIVE_PLAYERS; a ++  )
      aplayer[a]->move_scr();
     if ( DARK_MODE ) seeing();
-    if (ENEMIES_ON_GAME || GAME_MODE==ONE_PLAYER)
-    if ( (GAME_MODE!= NETWORK)||(NETWORK_MODE == SERVER ))
+
+    // ENEMIES_ON_GAME is a UI option visible only for deathmatch games
+    if ( ( KILLING_MODE != DEATHMATCH || ENEMIES_ON_GAME ) &&
+        ( GAME_MODE != NETWORK || NETWORK_MODE == SERVER ) )
     {
      roll_enemies();
      get_angles();


### PR DESCRIPTION
Fix enemies in split screen co-op mode.

Just to clarify that ENEMIES_ON_GAME is a Deathmatch-only setting (visible in UI). It's persistently stored to options file during game setup. It doesn't reflect the presence of enemies in non-deathmatch games.

Original condition was broken also for cases where persisting ENEMIES_ON_GAME was considered for non-deathmatch games.

Tested scenarios:
- Single player
- Split screen
  - Deathmatch
  - Co-op
- Network
  - Server
    - Deathmatch
    - Co-op
  - Client

Condition was shorted to implement as *if not true* due to less complex statements needed as opposed to *if true*. Other solutions welcome.

According to original TK 1.21 release notes this issue was eventually fixed but exists in the version this port is based on:

```
 1.21- * One major bug fixed: The enemies didn't move in splitscreen

        cooperative game in v1.2 !!!!
```