### PR TITLE
Fix ESC key in episode selection menu.

### DIFF
--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -48,6 +48,7 @@
 #define num_multip_options 7
 #define DIFF_K 10
 #define SPEC_K 21
+#define INVALID_EPISODE -1
  // Effects...
 #define BLOOD 0
 #define SMOKE 1

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2551,7 +2551,10 @@ void menu()
                 GAME_MODE = ONE_PLAYER;
                 KILLING_MODE = COOPERATIVE;
                 episode = choose_episode();
-                game();
+                if ( episode != INVALID_EPISODE )
+                {
+                    game();
+                }
                 menu_scr();
             }
             if ( selected == 1 )

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -161,7 +161,7 @@ int choose_episode()
             fadein( virbuff, pal ); first = 0;
         }
         memcpy( screen, virbuff, 64000 );
-        while( !k.state[94]&&!k.state[99]&&!k.state[28] )
+        while( !k.state[94]&&!k.state[99]&&!k.state[28]&&!k.state[1] )
         {
             if ( clock() != oclock )
             {
@@ -182,6 +182,11 @@ int choose_episode()
         {
             if ( sel < dirs - 1 ) sel ++;
             k.state[99] = 0;
+        }
+        if ( k.state[1] )
+        {
+            fadeout( virbuff, pal );
+            return INVALID_EPISODE;
         }
         pos = sel - 3;
         if ( pos < 0 ) pos = 0;


### PR DESCRIPTION
Fix ESC key in episode selection menu. Without it there is no way to get back to main menu except going to game and back.

![esc](https://user-images.githubusercontent.com/24453333/50308266-6a3be000-04a3-11e9-83a8-18658fc1fa2a.gif)
