### PR TITLE
Correction to check_places overflow fix.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -250,9 +250,9 @@ int check_place( int x, int y, int size )
     int a, ret = 0;
 
     // Check that the object fits to level vertically...
-    if ( ( ( y + size ) / 20 ) >= level_y_size ) ret = 1;
+    if ( ( ( y + size ) / 20 ) >= level_y_size ) return 1;
     // ... and horizontally
-    if ( ( ( x + size ) / 20 ) >= level_x_size ) ret = 1;
+    if ( ( ( x + size ) / 20 ) >= level_x_size ) return 1;
 
     if ( level[( y / 20 ) *level_x_size + ( x / 20 ) ].type!= FLOOR ) ret = 1;
     if ( level[( ( y + size )  / 20 ) *level_x_size + ( x / 20 ) ].type!= FLOOR ) ret = 1;


### PR DESCRIPTION
PR  #31 had a mistake which still let `check_places` function to read out-of-bounds memory. Fix was naturally supposed to return in case area is out of bounds.