### PR TITLE
Fix or suppress warnings on Visual Studio build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ find_package(SDL2_net REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-if (NOT WIN32)
+if (WIN32)
+	add_compile_options(/wd4244 /wd4996)
+else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsigned-char -Wall -Wno-pedantic -Wno-sign-compare")
 endif()
 

--- a/SRC/DRAW.CPP
+++ b/SRC/DRAW.CPP
@@ -890,7 +890,7 @@ void draw_targets()
         for ( a = 0; a < dist &&x - aplayer[0]->scr_x >= 0 &&x - aplayer[0]->scr_x < 320 &&y - aplayer[0]->scr_y >= 0 &&y - aplayer[0]->scr_y < scr_y_size &&level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == FLOOR; a ++  )
         {
             if ( ( a - ( int ) ( plot_count / 2 )  )  % 6 == 0 )
-            virbuff[( int ) ( y - aplayer[0]->scr_y ) *320 + ( int ) ( x - aplayer[0]->scr_x ) ] = 9*16;
+            virbuff[( int ) ( y - aplayer[0]->scr_y ) *320 + ( int ) ( x - aplayer[0]->scr_x ) ]= ( char ) ( 9 * 16 );
             x += sini[aplayer[0]->rangle2];
             y += cosi[aplayer[0]->rangle2];
         }
@@ -908,7 +908,7 @@ void draw_targets()
             for ( a = 0; a < dist &&x - aplayer[0]->scr_x >= 0 &&x - aplayer[0]->scr_x < 160 &&y - aplayer[0]->scr_y >= 0 &&y - aplayer[0]->scr_y < scr_y_size &&level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == FLOOR; a ++  )
             {
                 if ( ( a - ( int ) ( plot_count / 2 )  )  % 6 == 0 )
-                virbuff[( int ) ( y - aplayer[0]->scr_y ) *320 + ( int ) ( x - aplayer[0]->scr_x ) ] = 9*16;
+                virbuff[( int ) ( y - aplayer[0]->scr_y ) *320 + ( int ) ( x - aplayer[0]->scr_x ) ] = ( char ) ( 9 * 16 );
                 x += sini[aplayer[0]->rangle2];
                 y += cosi[aplayer[0]->rangle2];
             }
@@ -924,7 +924,7 @@ void draw_targets()
             for ( a = 0; a < dist &&x - aplayer[1]->scr_x > 0 &&x - aplayer[1]->scr_x < 160 &&y - aplayer[1]->scr_y >= 0 &&y - aplayer[1]->scr_y < scr_y_size &&level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == FLOOR; a ++  )
             {
                 if ( ( a - ( int ) ( plot_count / 2 )  )  % 6 == 0 )
-                virbuff[( int ) ( y - aplayer[1]->scr_y ) *320 + ( int ) ( x - aplayer[1]->scr_x )  + 160] = 9*16;
+                virbuff[( int ) ( y - aplayer[1]->scr_y ) *320 + ( int ) ( x - aplayer[1]->scr_x )  + 160] = ( char ) ( 9 * 16 );
                 x += sini[aplayer[1]->rangle2];
                 y += cosi[aplayer[1]->rangle2];
             }

--- a/SRC/EFP/EFP.CPP
+++ b/SRC/EFP/EFP.CPP
@@ -38,7 +38,7 @@ void load_efp( const char *name, char *kuva, int offs )
     h = ((unsigned short *) data_p)[1];
     data_p += 4;
 
-    for ( p = 0; p < w * h; )
+    for ( p = 0; p < (unsigned int) (w * h); )
     {
         tavu = *data_p++;
         if ( tavu > 192 )

--- a/SRC/FADE.CPP
+++ b/SRC/FADE.CPP
@@ -29,7 +29,8 @@ void Draw_Phase( int phase, char *image, char *pal )
 #define FADE_SPEED 10
 void fadein( char *image, char *pal )
 {
-    int old_c = 0, alku;
+    unsigned int alku;
+    int old_c = 0;
     setpal( pal, 0 );
     alku = framecount;
     while( alku + ( 256 / FADE_SPEED )  > framecount )
@@ -45,7 +46,8 @@ void fadein( char *image, char *pal )
 
 void fadeout( char *image, char *pal )
 {
-    int alku, old_c;
+    unsigned int alku;
+    int old_c;
     alku = old_c = framecount;
     while( alku + ( 256 / FADE_SPEED )  > framecount )
     {

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -637,7 +637,7 @@ void move_body_parts()
             if ( body_part[a].speed > 0 )
             {
                 body_part[a].move();
-                body_part[a].speed -= 0.2;
+                body_part[a].speed -= 0.2f;
             }
 }
 
@@ -678,7 +678,7 @@ void move_enemies()
         {
             if ((int) enemy[a].PUSH_POWER > 0 )
                 enemy[a].move( enemy[a].PUSH_ANGLE, (int) enemy[a].PUSH_POWER );
-            enemy[a].PUSH_POWER -= 0.2;
+            enemy[a].PUSH_POWER -= 0.2f;
         }
     }
 }
@@ -690,7 +690,7 @@ void push_players()
         {
             if ((int) aplayer[a]->PUSH_POWER > 0 )
                 aplayer[a]->move( aplayer[a]->PUSH_ANGLE, (int) aplayer[a]->PUSH_POWER, a );
-            aplayer[a]->PUSH_POWER -= 0.2;
+            aplayer[a]->PUSH_POWER -= 0.2f;
         }
 }
 
@@ -857,7 +857,7 @@ void chk_burn()
             if ( a == aplayer[0]->tindex || (GAME_MODE == SPLIT_SCREEN && a == aplayer[1]->tindex))
             {
                 player[a].burning --;
-                player[a].get_damage( 0.4, player[a].Frying_player );
+                player[a].get_damage( 0.4f, player[a].Frying_player );
             }
 
             if ( aplayer[0]->tindex == a && GAME_MODE == NETWORK )
@@ -877,7 +877,7 @@ void chk_burn()
         if ( ! enemy[a].DEAD && enemy[a].burning )
         {
             enemy[a].burning --;
-            enemy[a].get_damage( 0.4, enemy[a].Frying_player );
+            enemy[a].get_damage( 0.4f, enemy[a].Frying_player );
             if ( Steam_count % 6 == 0 )
                 new_effect( NULL, STEAM, enemy[a].x + 14, enemy[a].y + 14, 135, 1 );
         }

--- a/SRC/MISCFUNC.CPP
+++ b/SRC/MISCFUNC.CPP
@@ -385,7 +385,7 @@ void define_bullet_types()
     bullet_type[8].type = INCENDIARY;
     bullet_type[8].stop = 1;
     bullet_type[8].speed = 5;
-    bullet_type[8].power = 0.4;
+    bullet_type[8].power = 0.4f;
     bullet_type[8].push_power = 0;
     bullet_type[8].time = ( 5*18 )  / 5;
     bullet_type[8].explos = 0;
@@ -393,7 +393,7 @@ void define_bullet_types()
     bullet_type[8].light = &explo_l;
     bullet_type[8].lsize = 2;
     bullet_type[8].llum =  - 10;
-    bullet_type[8].ladd = 0.7;
+    bullet_type[8].ladd = 0.7f;
     bullet_type[8].effect = 0;
     bullet_type[8].cost = 6;
     bullet_type[8].amount_in_crate = 500;// div mul = 50


### PR DESCRIPTION
Supress two warnings
- C4244
  - _'conversion' conversion from 'type1' to 'type2', possible loss of data_
- C4996
  - _Calling any of the potentially unsafe methods in the C++ Standard Library results in Compiler Warning (level 3) C4996._

Fix rest of the warnings.