### PR TITLE
Monitor server connection on client side.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -1704,6 +1704,14 @@ void do_client_shit()
     char *str;
     int pl;
 
+    // Check that server connection is still alive
+    if ( !tk_port::net::active_connections_exist() )
+    {
+        warn("Lost connection to server\n");
+        quit = 1;
+        return;
+    }
+
     for ( a = 0; a < RECEIVERS; a ++  )
     if ( tk_port::net::receive(rec[a]) )
     {

--- a/SRC/NET/NET.CPP
+++ b/SRC/NET/NET.CPP
@@ -156,6 +156,16 @@ void accept_connections()
     }
 }
 
+bool active_connections_exist()
+{
+    const auto doesSocketExist = [](const TCPsocket& socket) {
+        return socket != nullptr;
+    };
+
+    // Find if there exists one or more active sockets
+    return std::find_if(sockets.begin(), sockets.end(), doesSocketExist) != sockets.end();
+}
+
 static void disconnect(const unsigned int index)
 {
     // Disconnect is not propagated up but server

--- a/SRC/NET/NET.H
+++ b/SRC/NET/NET.H
@@ -38,6 +38,8 @@ void close_connections();
 
 void accept_connections();
 
+bool active_connections_exist();
+
 bool receive(struct packet *buffer);
 void sendpacket(struct nodeaddr destnode, struct packet *packetet, word len);
 


### PR DESCRIPTION
Issue #71 

Client side.

Quit if server connection unexpectedly closed which might happen if network fails or server crashes.
Prevents clients from staying in non-functional network game.
Returns to main menu, like in expected server shutdown in which case server sends IPX_SERVERSHUTDOWN broadcast.