### PR TITLE
Filter string input characters.

### DIFF
--- a/SRC/KEYB.H
+++ b/SRC/KEYB.H
@@ -22,10 +22,12 @@ struct KeyboardHandler
             state[i] = 0;
         }
         _kbhit_flag = 0;
+        _getchhit_flag = 0;
         _last_getch = 0;
     }
 
     int _kbhit_flag;
+    int _getchhit_flag;
     int _last_getch;
 
     int kbhit()
@@ -40,10 +42,11 @@ struct KeyboardHandler
 
     int getch()
     {
-        while (!kbhit())
+        while ( !_getchhit_flag )
         {
             tk_port::event_tick();
         }
+        _getchhit_flag = 0;
         return _last_getch;
     }
 

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -207,9 +207,25 @@ void deinit()
     SDL_Quit();
 }
 
-uint8_t remap_key( SDL_Keycode keycode )
+bool is_string_input_key( SDL_Keycode keycode, uint8_t& rOut )
 {
-    return keycode & 0xFF;
+    if ( ( keycode >= SDLK_a && keycode <= SDLK_z ) ||
+        ( keycode >= SDLK_0 && keycode <= SDLK_9 ) ||
+        keycode == SDLK_PERIOD ||
+        keycode == SDLK_RETURN ||
+        keycode == SDLK_KP_ENTER ||
+        keycode == SDLK_RETURN2 ||
+        keycode == SDLK_SPACE ||
+        keycode == SDLK_BACKSPACE ||
+        keycode == SDLK_ESCAPE )
+    {
+        rOut = keycode & 0xFF;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 uint8_t get_scancode_index( SDL_Keycode keycode, SDL_Scancode scancode )
@@ -316,13 +332,20 @@ void event_tick( void )
 
                 if ( down )
                 {
-                    const uint8_t tk_key = remap_key( e.key.keysym.sym );
+                    uint8_t tk_key;
+                    const bool is_string_key = is_string_input_key( e.key.keysym.sym, tk_key );
 
-                    if ( debug )
+                    if ( is_string_key )
                     {
-                        printf( "key down: %04x (tk = %d)\n", e.key.keysym.scancode, tk_key );
+                        if ( debug )
+                        {
+                            printf( "key down: %04x (tk = %d)\n", e.key.keysym.scancode, tk_key );
+                        }
+
+                        k._last_getch = tk_key;
+                        k._getchhit_flag = true;
                     }
-                    k._last_getch = tk_key;
+
                     k._kbhit_flag = true;
                 }
             }


### PR DESCRIPTION
**Open for discussion.**

Issue #69 

Only allow alphanumeric input and period (for IP input) and Enter, Backspace ESC and Space.

Separate hit-flag because shop expects that symbol key ("Shoot" binded to e.g. TAB) triggers `kbhit()`. Also other screens waiting for any input using `kbhit()` should progress with any key.