### PR TITLE
Check for SDL quit while in actual game.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2445,6 +2445,12 @@ void game()
                     frame_count ++;
                 }
                 tk_port::event_tick();
+
+                if ( tk_port::quit_flag )
+                {
+                    quit = 1;
+                    BACK_TO_MENU = 1;
+                }
             }  // game loop end
 
             if ( DARK_MODE )

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -298,6 +298,12 @@ void event_tick( void )
         switch (e.type)
         {
             case SDL_QUIT:
+                if ( quit_flag )
+                {
+                    // Exit with force if app didn't quit with first press. App doesn't
+                    // poll for quit_flag in many places.
+                    exit( 1 );
+                }
                 quit_flag = true;
                 break;
             case SDL_KEYUP:


### PR DESCRIPTION
Partially fix #68 

Gracefully shut down game if window closing button is pressed during actual game play.

Adding `sdl_quit` polling to all menus and screens would be more work. Exit with force if app didn't quit with first try as a workaround.