### PR TITLE
Limit port framerate to avoid high CPU usage.

### DIFF
--- a/SRC/FADE.CPP
+++ b/SRC/FADE.CPP
@@ -35,7 +35,8 @@ void fadein( char *image, char *pal )
     alku = framecount;
     while( alku + ( 256 / FADE_SPEED )  > framecount )
     {
-        while ( framecount == old_c );
+        while ( framecount == old_c )
+            tk_port::event_tick();
         old_c = framecount;
         Draw_Phase( 256 - ( framecount - alku ) *FADE_SPEED, image, pal );
     }
@@ -51,7 +52,8 @@ void fadeout( char *image, char *pal )
     alku = old_c = framecount;
     while( alku + ( 256 / FADE_SPEED )  > framecount )
     {
-        while ( framecount == old_c );
+        while ( framecount == old_c )
+            tk_port::event_tick();
         old_c = framecount;
         Draw_Phase( ( framecount - alku ) *FADE_SPEED, image, pal );
     }

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2532,8 +2532,8 @@ void menu()
                 draw_ball( 320 - 75, 100 - starty + ( selected*15 )  - 2, cnt );
                 cnt ++;
                 if ( cnt > 23 ) cnt = 0;
-                tk_port::event_tick();
             }
+            tk_port::event_tick();
             if (tk_port::quit_flag) {
                 quit = 1;
             }

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -184,7 +184,7 @@ int init()
 {
     int ret;
     read_tk_port_debug();
-    if ( SDL_Init(SDL_INIT_EVERYTHING) != 0 )
+    if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS ) != 0 )
     {
         SDL_Log( "Error initializing SDL:  %s", SDL_GetError());
         return 1;
@@ -290,6 +290,29 @@ void present_screen( void )
     SDL_DestroyTexture( surface_texture );
 }
 
+int clamp( int val, int min, int max )
+{
+    if ( val < min ) return min;
+    if ( val > max ) return max;
+    return val;
+}
+
+void frame_rate_limiter( const unsigned int max_fps )
+{
+    static unsigned int frame_start_time = SDL_GetTicks();
+
+    const unsigned int max_delay = 1000 / max_fps;
+    const unsigned int since_last_frame = SDL_GetTicks() - frame_start_time;
+    const unsigned int delay = clamp( max_delay - since_last_frame, 0, max_delay );
+
+    if ( delay > 0 )
+    {
+        SDL_Delay( delay );
+    }
+
+    frame_start_time = SDL_GetTicks();
+}
+
 void event_tick( void )
 {
     SDL_Event e;
@@ -337,18 +360,15 @@ void event_tick( void )
         }
     }
     present_screen();
+
+    // To avoid running in busy loop taking all the CPU time,
+    // limit the speed to nice multiple of target frame rate
+    frame_rate_limiter( target_frames * 4 );
 }
 
 void save_screenshot( const char* path )
 {
     SDL_SaveBMP( surface, path );
-}
-
-static int clamp( int val, int min, int max )
-{
-    if ( val < min ) return min;
-    if ( val > max ) return max;
-    return val;
 }
 
 void set_palette( char palette_entries[768], int brightness )


### PR DESCRIPTION
Issue #78 

Port framerate is limited to 4 times the target rate to mitigate any jitter.
Initialize SDL with required flags to remove unnecessary threads.
Move few event_tick calls so that they limit framerate in certain views.