### PR TITLE
Enable warnings-as-errors on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(SDL2_net REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if (WIN32)
-	add_compile_options(/wd4244 /wd4996)
+	add_compile_options(/WX /wd4244 /wd4996)
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsigned-char -Wall -Wno-pedantic -Wno-sign-compare")
 endif()

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2699,4 +2699,5 @@ int main( int argc, char *argv[] )
     free_all();
     tk_port::deinit();
 //  credits();
+    return 0;
 }

--- a/SRC/WRITE.CPP
+++ b/SRC/WRITE.CPP
@@ -186,7 +186,7 @@ void readline( int x, int y, int len, char *str, char *screen, bool (*filter_cha
             memcpy( screen + x + ((dy + y) * 320), virbuff + x + ((dy + y) * 320), len * f_x_size[FONT_NUM] );
         scancode = k::wait_for_keypress();
         if ( scancode != k::ESC && scancode != k::BACKSPACE && scancode != k::ENTER )
-            if ( strlen( str ) < (len - 1))
+            if ( (int)strlen( str ) < (len - 1))
             {
                 char key = k::scancode_to_char( scancode );
                 if ( filter_char( key ) )


### PR DESCRIPTION
Enable `WX` to treat warnings as errors.

Fix few warnings visible on some setups.