### PR TITLE
Toggle fullscreen with Alt+Enter.

### DIFF
--- a/SRC/KEYB.CPP
+++ b/SRC/KEYB.CPP
@@ -102,6 +102,12 @@ void handle_event( const SDL_Event *e )
                 exit( 42 );
             }
 
+            if ( e->key.keysym.scancode == SDL_SCANCODE_RETURN && e->key.keysym.mod & KMOD_LALT )
+            {
+                toggle_fullscreen();
+                return;
+            }
+
             pressed_keys.insert( e->key.keysym.scancode );
 
             last_pressed_key.scancode = e->key.keysym.scancode;

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -21,6 +21,7 @@ bool window_resized;
 bool quit_flag = false;
 uint32_t debug = 0;
 uint64_t timer_zero;
+bool full_screen = false;
 
 #define TK_PORT_NSEC_PER_SEC 1000000000L
 #define TK_PORT_NSEC_PER_MSEC 1000000L
@@ -408,6 +409,17 @@ int vintage_clock()
 {
     uint64_t nsec_time = nanoclock();
     return (int) (nsec_time * VINTAGE_CLOCKS_PER_SEC / TK_PORT_NSEC_PER_SEC);
+}
+
+void toggle_fullscreen()
+{
+    full_screen = !full_screen;
+
+    // Borderless is used as it is very quick compared to real fullscreen. Latter
+    // has very slow and ugly transition (away from fullscreen) at least on some
+    // Windows 10 setups
+    SDL_SetWindowFullscreen( window, full_screen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0 );
+    window_resized = true;
 }
 
 /**

--- a/SRC/PORT.H
+++ b/SRC/PORT.H
@@ -33,7 +33,9 @@ void set_palette( char palette_entries[768], int brightness );
 
 void sleep( const int msec );
 
-int vintage_clock();
+int vintage_clock( void );
+
+void toggle_fullscreen( void );
 
 extern bool quit_flag;
 extern uint32_t debug;


### PR DESCRIPTION
It seems that Option+Enter could also work on Mac, hoping some OSX user could check that.

I tried few apps that I could think of which support Alt+Enter and those supported only **Left** Alt+Enter. That's what I also implemented. Please let me know if you think also Right Alt should be supported.