### PR TITLE
Change Frames Per Second key from F to F5.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -604,10 +604,10 @@ void chkeys()
         MAP_ON = !MAP_ON ? 1 : 0;
         k::clear(k::SPACE);
     }
-    if ( k::state(k::CHR_F) )
+    if ( k::state(k::F5) )
     {
         FRAMES_ON = FRAMES_ON == 0 ? 1 : 0;
-        k::clear(k::CHR_F);
+        k::clear(k::F5);
     }
     if ( k::state(k::F12) )
     {

--- a/SRC/KEYB.H
+++ b/SRC/KEYB.H
@@ -32,6 +32,7 @@ namespace keyb
     const SDL_Scancode CHR_0 = SDL_SCANCODE_0;
     const SDL_Scancode CHR_F = SDL_SCANCODE_F;
     const SDL_Scancode CHR_Y = SDL_SCANCODE_Y;
+    const SDL_Scancode F5 = SDL_SCANCODE_F5;
     const SDL_Scancode F12 = SDL_SCANCODE_F12;
 
     void init( int );

--- a/SRC/KEYB.H
+++ b/SRC/KEYB.H
@@ -30,7 +30,6 @@ namespace keyb
     const SDL_Scancode CHR_8 = SDL_SCANCODE_8;
     const SDL_Scancode CHR_9 = SDL_SCANCODE_9;
     const SDL_Scancode CHR_0 = SDL_SCANCODE_0;
-    const SDL_Scancode CHR_F = SDL_SCANCODE_F;
     const SDL_Scancode CHR_Y = SDL_SCANCODE_Y;
     const SDL_Scancode F5 = SDL_SCANCODE_F5;
     const SDL_Scancode F12 = SDL_SCANCODE_F12;


### PR DESCRIPTION
Issue #90 

F5 is the key used in TK321. Also gets rid of possible conflict with user selected keys as F5 is not possible player key.