### PR TITLE
Game controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ too!
 Key bindings
 ------------
 
-Player 1 and 2 game controls be customized under `OPTIONS -> PLAYER
-OPTIONS -> DEFINE KEYS 1/2`. Other keys are hard-coded.
+Player 1 and 2 game controls can be customized under `OPTIONS ->
+PLAYER OPTIONS -> DEFINE KEYS 1/2`.
+
+Game controllers are also supported but buttons need to be configured
+in options before playing. No more than two controllers are recognized
+at the same time. Analog inputs or navigating in menus is not
+currently supported.
+
+Other than player keys are hard-coded.
 
 **Note:** Some Apple keyboards don't have a right ctrl key. If you
 have such a keyboard, you have to change the player 1 shoot key before
@@ -149,7 +156,7 @@ On Windows, you may need to explicitly specify paths to your SDL libraries, like
 ```shell
 cmake -DSDL2_PATH="C:\\<path>\\SDL2-2.0.9" -DSDL2_MIXER_PATH="C:\\<path>\\SDL2_mixer-2.0.4" -DSDL2_NET_PATH="C:\\<path>\\SDL2_net-2.0.1" .
 ```
-which produced project files for 32-bit target. For 64-bit target, use e.g. `cmake -G "Visual Studio 15 2017 Win64"`.
+which produces project files for 32-bit target. For 64-bit target, use e.g. `cmake -G "Visual Studio 15 2017 Win64"`.
 
 
 [suomipelit-gh]: https://github.com/suomipelit

--- a/SRC/CLASSES.CPP
+++ b/SRC/CLASSES.CPP
@@ -1308,7 +1308,7 @@ void Level::load( char name[13] )
 void Keys::change()
 {
     int a = 0, quit = 0, cnt = 0, oclock = 0, selected = 0;
-    SDL_Scancode b = k::NOTHING;
+    tk_port::Input b = k::NOTHING;
     first = 1;
     fadeout( virbuff, pal );
     load_efp( "EFPS/COOL.EFP", picture, 0 );

--- a/SRC/CLASSES.H
+++ b/SRC/CLASSES.H
@@ -4,6 +4,7 @@
 #include "DEFINES.H"
 #include "TYPES.H"
 #include "NET/NET.H"
+#include "INPUT.H"
 
 class Crate_info
 {
@@ -173,7 +174,7 @@ class Player
     nodeaddr node;
     char name[10];
     int HIT, WALK, FIRE, DEAD, KICK, ANIM;
-    SDL_Scancode K_LEFT, K_RIGHT, K_UP, K_DOWN, K_SHOOT, K_SHIFT, K_STRAFE, K_LSTRAFE, K_RSTRAFE;
+    tk_port::Input K_LEFT, K_RIGHT, K_UP, K_DOWN, K_SHOOT, K_SHIFT, K_STRAFE, K_LSTRAFE, K_RSTRAFE;
     int TARGET;
     float PUSH_POWER;
     int PUSH_ANGLE;
@@ -215,7 +216,7 @@ class Bullet
 class Keys
 {
     public:
-    SDL_Scancode K_LEFT, K_RIGHT, K_UP, K_DOWN, K_SHOOT, K_SHIFT, K_STRAFE, K_LSTRAFE, K_RSTRAFE;
+    tk_port::Input K_LEFT, K_RIGHT, K_UP, K_DOWN, K_SHOOT, K_SHIFT, K_STRAFE, K_LSTRAFE, K_RSTRAFE;
     void change();
 };
 

--- a/SRC/CONTROLLER.CPP
+++ b/SRC/CONTROLLER.CPP
@@ -4,57 +4,46 @@
 
 namespace tk_port
 {
-Controller::Controller(const unsigned int index) :
-    m_sdl_controller(SDL_GameControllerOpen(index))
+Controller::Controller(const unsigned int index, const KeyMapVector* key_map) :
+    m_sdl_controller(SDL_GameControllerOpen(index)), m_id(-1), m_key_map(key_map)
 {
+    if (m_sdl_controller)
+    {
+        m_id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(m_sdl_controller));
+    }
 }
 
 Controller::~Controller()
 {
-    if (m_sdl_controller) SDL_GameControllerClose(m_sdl_controller);
-}
-
-bool Controller::isConnected()
-{
-    return m_sdl_controller && SDL_GameControllerGetAttached(m_sdl_controller) == SDL_TRUE;
-}
-
-bool Controller::isButtonPressed(const SDL_GameControllerButton controller_button)
-{
-    const auto it = std::find(m_pressed.begin(), m_pressed.end(), controller_button);
-
-    if (it != m_pressed.end())
+    if (m_sdl_controller)
     {
-        return false;
-    }
-    else
-    {
-        const auto is_down = SDL_GameControllerGetButton(m_sdl_controller, controller_button) == 1;
-
-        if (is_down)
-        {
-            m_pressed.push_back(controller_button);
-        }
-
-        return is_down;
+        SDL_GameControllerClose(m_sdl_controller);
     }
 }
 
-bool Controller::isButtonReleased(const SDL_GameControllerButton controller_button)
+bool Controller::getControllerInput(const SDL_GameControllerButton sdl_button, ControllerInput& r_input) const
 {
-    const auto it = std::find(m_pressed.begin(), m_pressed.end(), controller_button);
+    const auto inputFinder = [&sdl_button](const key_map_s& map) {
+        return sdl_button == map.controller;
+    };
 
-    if (it != m_pressed.end())
+    const auto it = std::find_if(m_key_map->begin(), m_key_map->end(), inputFinder);
+
+    if (it != m_key_map->end())
     {
-        const auto is_down = SDL_GameControllerGetButton(m_sdl_controller, controller_button);
-
-        if (!is_down)
-        {
-            m_pressed.erase(it);
-            return true;
-        }
+        r_input = it->input;
+        return true;
     }
-
     return false;
+}
+
+SDL_JoystickID Controller::getId() const
+{
+    return m_id;
+}
+
+const KeyMapVector* Controller::getKeyMap() const
+{
+    return m_key_map;
 }
 }

--- a/SRC/CONTROLLER.CPP
+++ b/SRC/CONTROLLER.CPP
@@ -1,0 +1,60 @@
+#include "CONTROLLER.H"
+
+#include <algorithm>
+
+namespace tk_port
+{
+Controller::Controller(const unsigned int index) :
+    m_sdl_controller(SDL_GameControllerOpen(index))
+{
+}
+
+Controller::~Controller()
+{
+    if (m_sdl_controller) SDL_GameControllerClose(m_sdl_controller);
+}
+
+bool Controller::isConnected()
+{
+    return m_sdl_controller && SDL_GameControllerGetAttached(m_sdl_controller) == SDL_TRUE;
+}
+
+bool Controller::isButtonPressed(const SDL_GameControllerButton controller_button)
+{
+    const auto it = std::find(m_pressed.begin(), m_pressed.end(), controller_button);
+
+    if (it != m_pressed.end())
+    {
+        return false;
+    }
+    else
+    {
+        const auto is_down = SDL_GameControllerGetButton(m_sdl_controller, controller_button) == 1;
+
+        if (is_down)
+        {
+            m_pressed.push_back(controller_button);
+        }
+
+        return is_down;
+    }
+}
+
+bool Controller::isButtonReleased(const SDL_GameControllerButton controller_button)
+{
+    const auto it = std::find(m_pressed.begin(), m_pressed.end(), controller_button);
+
+    if (it != m_pressed.end())
+    {
+        const auto is_down = SDL_GameControllerGetButton(m_sdl_controller, controller_button);
+
+        if (!is_down)
+        {
+            m_pressed.erase(it);
+            return true;
+        }
+    }
+
+    return false;
+}
+}

--- a/SRC/CONTROLLER.H
+++ b/SRC/CONTROLLER.H
@@ -1,6 +1,8 @@
 #ifndef _CONTROLLER_H
 #define _CONTROLLER_H
 
+#include "INPUT.H"
+#include <SDL_events.h>
 #include <SDL_gamecontroller.h>
 #include <vector>
 
@@ -9,19 +11,20 @@ namespace tk_port
 class Controller
 {
 public:
-    Controller(const unsigned int index);
+    Controller(const unsigned int index, const KeyMapVector* key_map);
 
     ~Controller();
 
-    bool isConnected();
+    bool getControllerInput(const SDL_GameControllerButton sdl_event, ControllerInput& r_input) const;
 
-    bool isButtonPressed(const SDL_GameControllerButton controller_button);
+    SDL_JoystickID getId() const;
 
-    bool isButtonReleased(const SDL_GameControllerButton controller_button);
+    const KeyMapVector* getKeyMap() const;
 
 private:
-    SDL_GameController *m_sdl_controller;
-    std::vector<SDL_GameControllerButton> m_pressed;
+    SDL_GameController* m_sdl_controller;
+    SDL_JoystickID m_id;
+    const KeyMapVector* m_key_map;
 };
 }
 

--- a/SRC/CONTROLLER.H
+++ b/SRC/CONTROLLER.H
@@ -1,0 +1,28 @@
+#ifndef _CONTROLLER_H
+#define _CONTROLLER_H
+
+#include <SDL_gamecontroller.h>
+#include <vector>
+
+namespace tk_port
+{
+class Controller
+{
+public:
+    Controller(const unsigned int index);
+
+    ~Controller();
+
+    bool isConnected();
+
+    bool isButtonPressed(const SDL_GameControllerButton controller_button);
+
+    bool isButtonReleased(const SDL_GameControllerButton controller_button);
+
+private:
+    SDL_GameController *m_sdl_controller;
+    std::vector<SDL_GameControllerButton> m_pressed;
+};
+}
+
+#endif

--- a/SRC/CONTROLLERS.CPP
+++ b/SRC/CONTROLLERS.CPP
@@ -1,0 +1,97 @@
+#include "CONTROLLERS.H"
+#include "KEYB.H"
+#include "INPUT.H"
+
+#include "SDL_events.h"
+#include <algorithm>
+
+namespace tk_port
+{
+void Controllers::handle_event(const SDL_Event *e)
+{
+    switch (e->type)
+    {
+    case SDL_CONTROLLERBUTTONUP:
+    case SDL_CONTROLLERBUTTONDOWN:
+    {
+        const SDL_JoystickID id = e->cbutton.which;
+
+        for (const auto& controller : m_controllers)
+        {
+            if (id == controller->getId())
+            {
+                const SDL_GameControllerButton sdl_button = static_cast<SDL_GameControllerButton>(e->cbutton.button);
+                ControllerInput input;
+
+                // Check that button is supported
+                if (controller->getControllerInput(sdl_button, input))
+                {
+                    if (e->type == SDL_CONTROLLERBUTTONDOWN)
+                    {
+                        // "keyb" namespace is to be renamed to e.g. "input"
+                        keyb::pressed(input, SDL_GetTicks());
+                    }
+                    else
+                    {
+                        keyb::released(input);
+                    }
+                }
+                break;
+            }
+        }
+        break;
+    }
+    case SDL_CONTROLLERDEVICEADDED:
+    {
+        const unsigned int index = e->cdevice.which;
+
+        if (SDL_IsGameController(index))
+        {
+            std::vector<const KeyMapVector*> available_maps =
+            {
+                &s_key_map_p1, // Player 1
+                &s_key_map_p2  // Player 2
+            };
+
+            // Make sure there aren't already two connected controllers
+            if (m_controllers.size() < available_maps.size())
+            {
+                // Remove key maps which are already in use
+                for (const auto& controller : m_controllers)
+                {
+                    available_maps.erase(
+                        std::remove(available_maps.begin(), available_maps.end(), controller->getKeyMap()),
+                        available_maps.end()
+                    );
+                }
+
+                // There should be always at least one map available if getting this far
+                if (!available_maps.empty())
+                {
+                    // Select first available map
+                    m_controllers.emplace_back(new Controller(index, *(available_maps.begin())));
+                }
+            }
+        }
+        break;
+    }
+    case SDL_CONTROLLERDEVICEREMOVED:
+    {
+        const SDL_JoystickID id = e->cbutton.which;
+        const auto controllerFinder = [&id](const std::unique_ptr<Controller>& controller) {
+            return id == controller->getId();
+        };
+
+        const auto it = std::find_if(m_controllers.begin(), m_controllers.end(), controllerFinder);
+
+        if (it != m_controllers.end())
+        {
+            m_controllers.erase(it);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+}

--- a/SRC/CONTROLLERS.H
+++ b/SRC/CONTROLLERS.H
@@ -1,0 +1,19 @@
+#ifndef _CONTROLLERS_H
+#define _CONTROLLERS_H
+
+#include "CONTROLLER.H"
+#include <memory>
+
+namespace tk_port
+{
+class Controllers
+{
+public:
+    void handle_event(const SDL_Event *e);
+
+private:
+    std::vector< std::unique_ptr<Controller> > m_controllers;
+};
+}
+
+#endif

--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -47,7 +47,6 @@
 #define num_deathmatch_options 4
 #define num_multip_options 7
 #define DIFF_K 10
-#define SPEC_K 21
 #define INVALID_EPISODE -1
  // Effects...
 #define BLOOD 0

--- a/SRC/GLOBVAR.CPP
+++ b/SRC/GLOBVAR.CPP
@@ -114,31 +114,6 @@ const char *k_text[DIFF_K] =
     "back to menu"
 };
 
-struct special spec[SPEC_K] =
-{
-    {1, "esc"},
-    {15, "tab"},
-    {28, "enter"},
-    {29, "left ctrl"},
-    {90, "right ctrl"},
-    {42, "left shift"},
-    {54, "right shift"},
-    {57, "space"},
-    {58, "caps lock"},
-    {56, "alt"},
-    {92, "alt gr"},
-    {93, "home"},
-    {94, "arrow up"},
-    {100, "page down"},
-    {95, "page up"},
-    {96, "arrow left"},
-    {97, "arrow right"},
-    {98, "end"},
-    {99, "arrow down"},
-    {101, "insert"},
-    {102, "delete"},
-};
-
 Effect_type effect_type[10];
 char *screen = NULL;
 char virbuff[320*240];

--- a/SRC/GLOBVAR.H
+++ b/SRC/GLOBVAR.H
@@ -45,7 +45,6 @@ extern int pl_start_x[MAX_PLAYERS], pl_start_y[MAX_PLAYERS];
 extern int ACTIVE_PLAYERS, ENEMIES, LEVEL, DEAD_ENEMIES, ENEMIES_ON_GAME;
 extern int FRAMES_ON, target_frames, delau;
 extern const char *k_text[DIFF_K];
-extern struct special spec[SPEC_K];
 extern Effect_type effect_type[10];
 extern char *screen;
 extern char virbuff[];

--- a/SRC/INPUT.CPP
+++ b/SRC/INPUT.CPP
@@ -1,0 +1,60 @@
+#include "INPUT.H"
+#include <algorithm>
+#include <SDL_keyboard.h>
+
+namespace tk_port
+{
+Input::Input()
+    : value(0)
+{
+}
+
+Input::Input(const SDL_Scancode &scancode)
+    : scancode(scancode)
+{
+}
+
+Input::Input(const ControllerInput &scancode)
+    : controller_input(scancode)
+{
+}
+
+bool Input::operator < (const Input &rhs) const
+{
+    return value < rhs.value;
+}
+
+bool Input::operator == (const Input &rhs) const
+{
+    return value == rhs.value;
+}
+
+bool Input::operator != (const Input &rhs) const
+{
+    return value != rhs.value;
+}
+
+const char* Input::get_name() const
+{
+    return get_type() == Controller ?
+        get_controller_input_name() :
+        SDL_GetScancodeName(scancode);
+}
+
+Input::InputType Input::get_type() const
+{
+    return s_controller_input_bit & value ? Controller : Keyboard;
+}
+
+const char* Input::get_controller_input_name() const
+{
+    const auto find_button = [this](const key_name_map_s& map)
+    {
+        return map.input == controller_input;
+    };
+
+    const auto it = std::find_if(s_key_name_map.begin(), s_key_name_map.end(), find_button);
+
+    return it != s_key_name_map.end() ? it->name : "Unknown";
+}
+}

--- a/SRC/INPUT.H
+++ b/SRC/INPUT.H
@@ -70,7 +70,9 @@ struct key_map_s
     SDL_GameControllerButton controller;
 };
 
-const std::vector<key_map_s> s_key_map_p1
+using KeyMapVector = std::vector<key_map_s>;
+
+const KeyMapVector s_key_map_p1
 {
     { DPAD_UP_1, SDL_CONTROLLER_BUTTON_DPAD_UP, },
     { DPAD_DOWN_1, SDL_CONTROLLER_BUTTON_DPAD_DOWN },
@@ -88,7 +90,7 @@ const std::vector<key_map_s> s_key_map_p1
     { BUTTON_START_1, SDL_CONTROLLER_BUTTON_START }
 };
 
-const std::vector<key_map_s> s_key_map_p2
+const KeyMapVector s_key_map_p2
 {
     { DPAD_UP_2, SDL_CONTROLLER_BUTTON_DPAD_UP, },
     { DPAD_DOWN_2, SDL_CONTROLLER_BUTTON_DPAD_DOWN },
@@ -112,7 +114,9 @@ struct key_name_map_s
     const char* name;
 };
 
-const std::vector<key_name_map_s> s_key_name_map
+using KeyNameMapVector = std::vector<key_name_map_s>;
+
+const KeyNameMapVector s_key_name_map
 {
     { DPAD_UP_1, CONTROLLER_ONE_NAME " " CONTROLLER_UP },
     { DPAD_DOWN_1, CONTROLLER_ONE_NAME " " CONTROLLER_DOWN },

--- a/SRC/INPUT.H
+++ b/SRC/INPUT.H
@@ -1,0 +1,186 @@
+#ifndef _INPUT_H
+#define _INPUT_H
+
+#include <vector>
+#include "SDL_gamecontroller.h"
+#include "SDL_scancode.h"
+
+#define CONTROLLER_NAME "Cntrl"
+#define CONTROLLER_ONE_NAME CONTROLLER_NAME" 1"
+#define CONTROLLER_TWO_NAME CONTROLLER_NAME" 2"
+
+#define CONTROLLER_UP "Up"
+#define CONTROLLER_DOWN "Down"
+#define CONTROLLER_LEFT "Left"
+#define CONTROLLER_RIGHT "Right"
+#define CONTROLLER_A "A"
+#define CONTROLLER_B "B"
+#define CONTROLLER_Y "Y"
+#define CONTROLLER_X "X"
+#define CONTROLLER_LEFT_STICK "LS"
+#define CONTROLLER_RIGHT_STICK "RS"
+#define CONTROLLER_LEFT_SHOULDER "LB"
+#define CONTROLLER_RIGHT_SHOULDER "RB"
+#define CONTROLLER_BACK "Back"
+#define CONTROLLER_START "Start"
+
+namespace tk_port
+{
+const unsigned int s_controller_input_bit = 0x10000000;
+
+enum ControllerInput : uint32_t
+{
+    // ControllerInput enum starts beyond SDL_NUM_SCANCODES so that
+    // we can identify the type with simple bitwise and operation
+    DPAD_UP_1 = s_controller_input_bit,
+    DPAD_DOWN_1,
+    DPAD_LEFT_1,
+    DPAD_RIGHT_1,
+    BUTTON_A_1,
+    BUTTON_B_1,
+    BUTTON_Y_1,
+    BUTTON_X_1,
+    BUTTON_LEFT_STICK_1,
+    BUTTON_RIGHT_STICK_1,
+    BUTTON_LEFT_SHOULDER_1,
+    BUTTON_RIGHT_SHOULDER_1,
+    BUTTON_BACK_1,
+    BUTTON_START_1,
+
+    // Leave space for extension
+    DPAD_UP_2 = s_controller_input_bit | 0x80,
+    DPAD_DOWN_2,
+    DPAD_LEFT_2,
+    DPAD_RIGHT_2,
+    BUTTON_A_2,
+    BUTTON_B_2,
+    BUTTON_Y_2,
+    BUTTON_X_2,
+    BUTTON_LEFT_STICK_2,
+    BUTTON_RIGHT_STICK_2,
+    BUTTON_LEFT_SHOULDER_2,
+    BUTTON_RIGHT_SHOULDER_2,
+    BUTTON_BACK_2,
+    BUTTON_START_2
+};
+
+struct key_map_s
+{
+    ControllerInput input;
+    SDL_GameControllerButton controller;
+};
+
+const std::vector<key_map_s> s_key_map_p1
+{
+    { DPAD_UP_1, SDL_CONTROLLER_BUTTON_DPAD_UP, },
+    { DPAD_DOWN_1, SDL_CONTROLLER_BUTTON_DPAD_DOWN },
+    { DPAD_LEFT_1, SDL_CONTROLLER_BUTTON_DPAD_LEFT },
+    { DPAD_RIGHT_1, SDL_CONTROLLER_BUTTON_DPAD_RIGHT },
+    { BUTTON_A_1, SDL_CONTROLLER_BUTTON_A },
+    { BUTTON_B_1, SDL_CONTROLLER_BUTTON_B },
+    { BUTTON_Y_1, SDL_CONTROLLER_BUTTON_Y },
+    { BUTTON_X_1, SDL_CONTROLLER_BUTTON_X },
+    { BUTTON_LEFT_STICK_1, SDL_CONTROLLER_BUTTON_LEFTSTICK },
+    { BUTTON_RIGHT_STICK_1, SDL_CONTROLLER_BUTTON_RIGHTSTICK },
+    { BUTTON_LEFT_SHOULDER_1, SDL_CONTROLLER_BUTTON_LEFTSHOULDER },
+    { BUTTON_RIGHT_SHOULDER_1, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER },
+    { BUTTON_BACK_1, SDL_CONTROLLER_BUTTON_BACK },
+    { BUTTON_START_1, SDL_CONTROLLER_BUTTON_START }
+};
+
+const std::vector<key_map_s> s_key_map_p2
+{
+    { DPAD_UP_2, SDL_CONTROLLER_BUTTON_DPAD_UP, },
+    { DPAD_DOWN_2, SDL_CONTROLLER_BUTTON_DPAD_DOWN },
+    { DPAD_LEFT_2, SDL_CONTROLLER_BUTTON_DPAD_LEFT },
+    { DPAD_RIGHT_2, SDL_CONTROLLER_BUTTON_DPAD_RIGHT },
+    { BUTTON_A_2, SDL_CONTROLLER_BUTTON_A },
+    { BUTTON_B_2, SDL_CONTROLLER_BUTTON_B },
+    { BUTTON_Y_2, SDL_CONTROLLER_BUTTON_Y },
+    { BUTTON_X_2, SDL_CONTROLLER_BUTTON_X },
+    { BUTTON_LEFT_STICK_2, SDL_CONTROLLER_BUTTON_LEFTSTICK },
+    { BUTTON_RIGHT_STICK_2, SDL_CONTROLLER_BUTTON_RIGHTSTICK },
+    { BUTTON_LEFT_SHOULDER_2, SDL_CONTROLLER_BUTTON_LEFTSHOULDER },
+    { BUTTON_RIGHT_SHOULDER_2, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER },
+    { BUTTON_BACK_2, SDL_CONTROLLER_BUTTON_BACK },
+    { BUTTON_START_2, SDL_CONTROLLER_BUTTON_START }
+};
+
+struct key_name_map_s
+{
+    ControllerInput input;
+    const char* name;
+};
+
+const std::vector<key_name_map_s> s_key_name_map
+{
+    { DPAD_UP_1, CONTROLLER_ONE_NAME " " CONTROLLER_UP },
+    { DPAD_DOWN_1, CONTROLLER_ONE_NAME " " CONTROLLER_DOWN },
+    { DPAD_LEFT_1, CONTROLLER_ONE_NAME " " CONTROLLER_LEFT },
+    { DPAD_RIGHT_1, CONTROLLER_ONE_NAME " " CONTROLLER_RIGHT },
+    { BUTTON_A_1, CONTROLLER_ONE_NAME " " CONTROLLER_A },
+    { BUTTON_B_1, CONTROLLER_ONE_NAME " " CONTROLLER_B },
+    { BUTTON_Y_1, CONTROLLER_ONE_NAME " " CONTROLLER_Y },
+    { BUTTON_X_1, CONTROLLER_ONE_NAME " " CONTROLLER_X },
+    { BUTTON_LEFT_STICK_1, CONTROLLER_ONE_NAME " " CONTROLLER_LEFT_STICK },
+    { BUTTON_RIGHT_STICK_1, CONTROLLER_ONE_NAME " " CONTROLLER_RIGHT_STICK },
+    { BUTTON_LEFT_SHOULDER_1, CONTROLLER_ONE_NAME " " CONTROLLER_LEFT_SHOULDER },
+    { BUTTON_RIGHT_SHOULDER_1, CONTROLLER_ONE_NAME " " CONTROLLER_RIGHT_SHOULDER },
+    { BUTTON_BACK_1, CONTROLLER_ONE_NAME " " CONTROLLER_BACK },
+    { BUTTON_START_1, CONTROLLER_ONE_NAME " " CONTROLLER_START },
+
+    { DPAD_UP_2, CONTROLLER_TWO_NAME " " CONTROLLER_UP },
+    { DPAD_DOWN_2, CONTROLLER_TWO_NAME " " CONTROLLER_DOWN },
+    { DPAD_LEFT_2, CONTROLLER_TWO_NAME " " CONTROLLER_LEFT },
+    { DPAD_RIGHT_2, CONTROLLER_TWO_NAME " " CONTROLLER_RIGHT },
+    { BUTTON_A_2, CONTROLLER_TWO_NAME " " CONTROLLER_A },
+    { BUTTON_B_2, CONTROLLER_TWO_NAME " " CONTROLLER_B },
+    { BUTTON_Y_2, CONTROLLER_TWO_NAME " " CONTROLLER_Y },
+    { BUTTON_X_2, CONTROLLER_TWO_NAME " " CONTROLLER_X },
+    { BUTTON_LEFT_STICK_2, CONTROLLER_TWO_NAME " " CONTROLLER_LEFT_STICK },
+    { BUTTON_RIGHT_STICK_2, CONTROLLER_TWO_NAME " " CONTROLLER_RIGHT_STICK },
+    { BUTTON_LEFT_SHOULDER_2, CONTROLLER_TWO_NAME " " CONTROLLER_LEFT_SHOULDER },
+    { BUTTON_RIGHT_SHOULDER_2, CONTROLLER_TWO_NAME " " CONTROLLER_RIGHT_SHOULDER },
+    { BUTTON_BACK_2, CONTROLLER_TWO_NAME " " CONTROLLER_BACK },
+    { BUTTON_START_2, CONTROLLER_TWO_NAME " " CONTROLLER_START },
+};
+
+struct Input
+{
+    Input();
+
+    Input(const SDL_Scancode &scancode);
+
+    Input(const ControllerInput &scancode);
+
+    bool operator < (const Input &rhs) const;
+
+    bool operator == (const Input &rhs) const;
+
+    bool operator != (const Input &rhs) const;
+
+    const char* get_name() const;
+
+    enum InputType : uint8_t
+    {
+        Keyboard,
+        Controller
+    };
+
+    InputType get_type() const;
+
+    union
+    {
+        SDL_Scancode scancode : 32;
+        ControllerInput controller_input;
+        uint32_t value; // for comparison use
+    };
+
+private:
+    const char* get_controller_input_name() const;
+};
+
+static_assert(sizeof(Input) == 4, "Input size doesn't match to serialized options");
+}
+
+#endif

--- a/SRC/KEYB.CPP
+++ b/SRC/KEYB.CPP
@@ -14,12 +14,12 @@ const uint32_t SYMBOL_KEY_REPEAT_INTERVAL = 25;   // ms
 
 struct key_repeat
 {
-    SDL_Scancode scancode;
+    Input input;
     uint32_t pressed_time;
     int repeats;
 };
 
-std::set<SDL_Scancode> pressed_keys;
+std::set<Input> pressed_keys;
 key_repeat last_pressed_key = { NOTHING, 0, 0 };
 
 char scancode_to_char( SDL_Scancode scancode )
@@ -52,14 +52,14 @@ void init( int )
 
 void deinit() {}
 
-bool state( SDL_Scancode scancode )
+bool state( const Input& input )
 {
-    return pressed_keys.find( scancode ) != pressed_keys.end();
+    return pressed_keys.find( input ) != pressed_keys.end();
 }
 
-void clear( SDL_Scancode scancode )
+void clear( const Input& input)
 {
-    pressed_keys.erase( scancode );
+    pressed_keys.erase( input );
 }
 
 void clear_stack()
@@ -67,22 +67,40 @@ void clear_stack()
     pressed_keys.clear();
 }
 
-SDL_Scancode get_last_key()
+Input get_last_key()
 {
-    return state( last_pressed_key.scancode ) ?
-        last_pressed_key.scancode :
+    return state( last_pressed_key.input ) ?
+        last_pressed_key.input :
         NOTHING;
 }
 
-SDL_Scancode wait_for_keypress()
+Input wait_for_keypress()
 {
-    SDL_Scancode scancode;
-    while ( (scancode = get_last_key()) == NOTHING )
+    Input input;
+    while ( ( input = get_last_key()) == NOTHING )
     {
         event_tick();
     }
-    clear( scancode );
-    return scancode;
+    clear( input );
+    return input;
+}
+
+void pressed( const Input& input, const Uint32 timestamp )
+{
+    pressed_keys.insert( input );
+
+    last_pressed_key.input = input;
+    last_pressed_key.pressed_time = timestamp;
+    last_pressed_key.repeats = 0;
+}
+
+void released( const Input& input )
+{
+    clear( input );
+    if ( input == last_pressed_key.input )
+    {
+        last_pressed_key.input = NOTHING;
+    }
 }
 
 void handle_event( const SDL_Event *e )
@@ -108,20 +126,15 @@ void handle_event( const SDL_Event *e )
                 return;
             }
 
-            pressed_keys.insert( e->key.keysym.scancode );
+            pressed( e->key.keysym.scancode, e->key.timestamp );
 
-            last_pressed_key.scancode = e->key.keysym.scancode;
-            last_pressed_key.pressed_time = e->key.timestamp;
-            last_pressed_key.repeats = 0;
             break;
         }
 
         case SDL_KEYUP:
         {
-            clear( e->key.keysym.scancode );
-            if ( e->key.keysym.scancode == last_pressed_key.scancode ) {
-                last_pressed_key.scancode = NOTHING;
-            }
+            released( e->key.keysym.scancode );
+
             break;
         }
 
@@ -130,14 +143,14 @@ void handle_event( const SDL_Event *e )
             if (e->user.code != KEY_REPEAT_TIMER_CODE)
                 break;
 
-            if (last_pressed_key.scancode == NOTHING)
+            if (last_pressed_key.input == NOTHING)
                 break;
 
             uint32_t elapsed = e->user.timestamp - last_pressed_key.pressed_time;
             if ( elapsed >= SYMBOL_KEY_REPEAT_START +
                  last_pressed_key.repeats * SYMBOL_KEY_REPEAT_INTERVAL )
             {
-                pressed_keys.insert( last_pressed_key.scancode );
+                pressed_keys.insert( last_pressed_key.input );
                 last_pressed_key.repeats++;
             }
 

--- a/SRC/KEYB.H
+++ b/SRC/KEYB.H
@@ -3,49 +3,52 @@
 
 #include <SDL.h>
 #include "PORT.H"
+#include "INPUT.H"
 
 namespace tk_port
 {
 namespace keyb
 {
-    const SDL_Scancode NOTHING = SDL_SCANCODE_UNKNOWN;
-    const SDL_Scancode ESC = SDL_SCANCODE_ESCAPE;
-    const SDL_Scancode ARROW_UP = SDL_SCANCODE_UP;
-    const SDL_Scancode ARROW_DOWN = SDL_SCANCODE_DOWN;
-    const SDL_Scancode ARROW_LEFT = SDL_SCANCODE_LEFT;
-    const SDL_Scancode ARROW_RIGHT = SDL_SCANCODE_RIGHT;
-    const SDL_Scancode ENTER = SDL_SCANCODE_RETURN;
-    const SDL_Scancode BACKSPACE = SDL_SCANCODE_BACKSPACE;
-    const SDL_Scancode LEFT_SHIFT = SDL_SCANCODE_LSHIFT;
-    const SDL_Scancode GRAVE = SDL_SCANCODE_GRAVE;  // Left of 1
-    const SDL_Scancode MINUS = SDL_SCANCODE_MINUS;  // Right of 0
-    const SDL_Scancode SPACE = SDL_SCANCODE_SPACE;
-    const SDL_Scancode CHR_1 = SDL_SCANCODE_1;
-    const SDL_Scancode CHR_2 = SDL_SCANCODE_2;
-    const SDL_Scancode CHR_3 = SDL_SCANCODE_3;
-    const SDL_Scancode CHR_4 = SDL_SCANCODE_4;
-    const SDL_Scancode CHR_5 = SDL_SCANCODE_5;
-    const SDL_Scancode CHR_6 = SDL_SCANCODE_6;
-    const SDL_Scancode CHR_7 = SDL_SCANCODE_7;
-    const SDL_Scancode CHR_8 = SDL_SCANCODE_8;
-    const SDL_Scancode CHR_9 = SDL_SCANCODE_9;
-    const SDL_Scancode CHR_0 = SDL_SCANCODE_0;
-    const SDL_Scancode CHR_Y = SDL_SCANCODE_Y;
-    const SDL_Scancode F5 = SDL_SCANCODE_F5;
-    const SDL_Scancode F12 = SDL_SCANCODE_F12;
+    const Input NOTHING = SDL_SCANCODE_UNKNOWN;
+    const Input ESC = SDL_SCANCODE_ESCAPE;
+    const Input ARROW_UP = SDL_SCANCODE_UP;
+    const Input ARROW_DOWN = SDL_SCANCODE_DOWN;
+    const Input ARROW_LEFT = SDL_SCANCODE_LEFT;
+    const Input ARROW_RIGHT = SDL_SCANCODE_RIGHT;
+    const Input ENTER = SDL_SCANCODE_RETURN;
+    const Input BACKSPACE = SDL_SCANCODE_BACKSPACE;
+    const Input LEFT_SHIFT = SDL_SCANCODE_LSHIFT;
+    const Input GRAVE = SDL_SCANCODE_GRAVE;  // Left of 1
+    const Input MINUS = SDL_SCANCODE_MINUS;  // Right of 0
+    const Input SPACE = SDL_SCANCODE_SPACE;
+    const Input CHR_1 = SDL_SCANCODE_1;
+    const Input CHR_2 = SDL_SCANCODE_2;
+    const Input CHR_3 = SDL_SCANCODE_3;
+    const Input CHR_4 = SDL_SCANCODE_4;
+    const Input CHR_5 = SDL_SCANCODE_5;
+    const Input CHR_6 = SDL_SCANCODE_6;
+    const Input CHR_7 = SDL_SCANCODE_7;
+    const Input CHR_8 = SDL_SCANCODE_8;
+    const Input CHR_9 = SDL_SCANCODE_9;
+    const Input CHR_0 = SDL_SCANCODE_0;
+    const Input CHR_Y = SDL_SCANCODE_Y;
+    const Input F5 = SDL_SCANCODE_F5;
+    const Input F12 = SDL_SCANCODE_F12;
 
     void init( int );
     void deinit();
-    bool state( SDL_Scancode );
-    void clear( SDL_Scancode );
+    bool state( const Input& );
+    void clear( const Input& );
     void clear_stack();
+    void pressed( const Input& input, const Uint32 timestamp );
+    void released( const Input& input );
 
-    // Return scancode of the key that was pressed last, or NOTHING if
+    // Return key/button that was pressed last, or NOTHING if
     // no key is currently pressed.
-    SDL_Scancode get_last_key();
+    Input get_last_key();
 
-    // Wait until a key is pressed and return its scancode
-    SDL_Scancode wait_for_keypress();
+    // Wait until a key/button is pressed and return it
+    Input wait_for_keypress();
 
     // Return a character corresponding the given scancode
     char scancode_to_char( SDL_Scancode scancode );

--- a/SRC/MISCFUNC.CPP
+++ b/SRC/MISCFUNC.CPP
@@ -57,14 +57,14 @@ void change_name( int num )
  * @param key Keycode.
  * @return String for the keycode.
  */
-char *k_2_c( SDL_Scancode scancode )
+char *k_2_c( const tk_port::Input& scancode )
 {
-    return strdup( SDL_GetScancodeName( scancode ) );
+    return strdup( scancode.get_name() );
 }
 
-SDL_Scancode get_key( int x, int y )
+tk_port::Input get_key( int x, int y )
 {
-    SDL_Scancode key = k::NOTHING;
+    tk_port::Input key = k::NOTHING;
     int oclock = 0, cnt = 0, pressed = 0;
     while ( !pressed )
     {
@@ -76,7 +76,7 @@ SDL_Scancode get_key( int x, int y )
             if ( cnt > 23 ) cnt = 0;
         }
 
-        SDL_Scancode scancode = k::get_last_key();
+        tk_port::Input scancode = k::get_last_key();
 
         // Left shift is blacklisted in the original code. Dunno why.
         if ( scancode != k::NOTHING && scancode != k::LEFT_SHIFT )

--- a/SRC/MISCFUNC.H
+++ b/SRC/MISCFUNC.H
@@ -2,10 +2,11 @@
 #define __TK__MISCFUNC__
 
 #include <SDL.h>
+#include "INPUT.H"
 
 void change_name( int num );
-char *k_2_c( SDL_Scancode scancode );
-SDL_Scancode get_key( int x, int y );
+char *k_2_c( const tk_port::Input& scancode );
+tk_port::Input get_key( int x, int y );
 void clear_shit( int y );
 void set_keys();
 void alusta_client();

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -3,14 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <memory>
-#include <vector>
 #include <SDL.h>
 #include "PORT.H"
 #include "GLOBVAR.H"
 #include "ERROR/ERROR.H"
-#include "CONTROLLER.H"
-#include "INPUT.H"
+#include "CONTROLLERS.H"
 
 extern int scr_y_size;
 
@@ -26,8 +23,7 @@ bool quit_flag = false;
 uint32_t debug = 0;
 uint64_t timer_zero;
 bool full_screen = false;
-std::vector< std::unique_ptr<Controller> > controllers;
-const unsigned int max_number_of_controllers = 2;
+Controllers *controllers = NULL;
 
 #define TK_PORT_NSEC_PER_SEC 1000000000L
 #define TK_PORT_NSEC_PER_MSEC 1000000L
@@ -205,20 +201,6 @@ void change_resolution( const unsigned int y )
 
     init_screen();
 }
-
-void init_controllers( void )
-{
-    for ( int i = 0; i < SDL_NumJoysticks(); ++i )
-    {
-        if ( SDL_IsGameController( i ) )
-        {
-            controllers.emplace_back( new Controller(i) );
-            if ( controllers.size() == max_number_of_controllers )
-                break;
-        }
-    }
-}
-
 int init()
 {
     int ret;
@@ -232,7 +214,7 @@ int init()
         return ret;
     }
     init_time();
-    init_controllers();
+    controllers = new Controllers();
     event_tick();  // Tick once so we get the window up at this point
     return 0;
 }
@@ -240,7 +222,7 @@ int init()
 void deinit()
 {
     // Uninitialize SDL controllers before main SDL
-    controllers.clear();
+    delete controllers;
 
     if ( surface ) SDL_FreeSurface( surface );
     if ( palette ) SDL_FreePalette( palette );
@@ -358,47 +340,13 @@ void frame_rate_limiter( const unsigned int max_fps )
     frame_start_time = SDL_GetTicks();
 }
 
-void handle_controller_input( void )
-{
-    for ( unsigned int i = 0; i < controllers.size(); ++i )
-    {
-        const auto& controller = controllers[i];
-
-        if ( !controller->isConnected() )
-        {
-            // Logic could be improved so that disconnected controllers are reconnected. For now
-            // just ignore such controllers until end of the session.
-            continue;
-        }
-
-        const auto set_key_if = [&controller]( const SDL_GameControllerButton& controller_button, const ControllerInput& button )
-        {
-            if ( controller->isButtonPressed( controller_button ) )
-            {
-                keyb::pressed( button, SDL_GetTicks() );
-            }
-            else if (controller->isButtonReleased( controller_button ) )
-            {
-                keyb::released( button );
-            }
-        };
-
-        for ( const auto& key_pair : i == 0 ? s_key_map_p1 : s_key_map_p2 )
-        {
-            set_key_if( key_pair.controller, key_pair.input );
-        }
-    }
-}
-
 void event_tick( void )
 {
-    // Controllers emulate keyboard presses so any controller action is actually handled in the
-    // keyboard loop below
-    handle_controller_input();
-
     SDL_Event e;
     while (SDL_PollEvent( &e ))
     {
+        controllers->handle_event(&e);
+
         tk_port::keyb::handle_event(&e);
 
         switch (e.type)

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -3,10 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <memory>
+#include <vector>
 #include <SDL.h>
 #include "PORT.H"
 #include "GLOBVAR.H"
 #include "ERROR/ERROR.H"
+#include "CONTROLLER.H"
+#include "INPUT.H"
 
 extern int scr_y_size;
 
@@ -22,6 +26,8 @@ bool quit_flag = false;
 uint32_t debug = 0;
 uint64_t timer_zero;
 bool full_screen = false;
+std::vector< std::unique_ptr<Controller> > controllers;
+const unsigned int max_number_of_controllers = 2;
 
 #define TK_PORT_NSEC_PER_SEC 1000000000L
 #define TK_PORT_NSEC_PER_MSEC 1000000L
@@ -200,11 +206,24 @@ void change_resolution( const unsigned int y )
     init_screen();
 }
 
+void init_controllers( void )
+{
+    for ( int i = 0; i < SDL_NumJoysticks(); ++i )
+    {
+        if ( SDL_IsGameController( i ) )
+        {
+            controllers.emplace_back( new Controller(i) );
+            if ( controllers.size() == max_number_of_controllers )
+                break;
+        }
+    }
+}
+
 int init()
 {
     int ret;
     read_tk_port_debug();
-    if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS ) != 0 )
+    if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER ) != 0 )
     {
         SDL_Log( "Error initializing SDL:  %s", SDL_GetError());
         return 1;
@@ -213,12 +232,16 @@ int init()
         return ret;
     }
     init_time();
+    init_controllers();
     event_tick();  // Tick once so we get the window up at this point
     return 0;
 }
 
 void deinit()
 {
+    // Uninitialize SDL controllers before main SDL
+    controllers.clear();
+
     if ( surface ) SDL_FreeSurface( surface );
     if ( palette ) SDL_FreePalette( palette );
     if ( renderer ) SDL_DestroyRenderer( renderer );
@@ -335,8 +358,44 @@ void frame_rate_limiter( const unsigned int max_fps )
     frame_start_time = SDL_GetTicks();
 }
 
+void handle_controller_input( void )
+{
+    for ( unsigned int i = 0; i < controllers.size(); ++i )
+    {
+        const auto& controller = controllers[i];
+
+        if ( !controller->isConnected() )
+        {
+            // Logic could be improved so that disconnected controllers are reconnected. For now
+            // just ignore such controllers until end of the session.
+            continue;
+        }
+
+        const auto set_key_if = [&controller]( const SDL_GameControllerButton& controller_button, const ControllerInput& button )
+        {
+            if ( controller->isButtonPressed( controller_button ) )
+            {
+                keyb::pressed( button, SDL_GetTicks() );
+            }
+            else if (controller->isButtonReleased( controller_button ) )
+            {
+                keyb::released( button );
+            }
+        };
+
+        for ( const auto& key_pair : i == 0 ? s_key_map_p1 : s_key_map_p2 )
+        {
+            set_key_if( key_pair.controller, key_pair.input );
+        }
+    }
+}
+
 void event_tick( void )
 {
+    // Controllers emulate keyboard presses so any controller action is actually handled in the
+    // keyboard loop below
+    handle_controller_input();
+
     SDL_Event e;
     while (SDL_PollEvent( &e ))
     {

--- a/SRC/TYPES.H
+++ b/SRC/TYPES.H
@@ -1,12 +1,6 @@
 #ifndef __TK__TYPES__
 #define __TK__TYPES__
 
-struct special
-{
-    int num;
-    char text[15];
-};
-
 struct BLOCK
 {
     int type;

--- a/SRC/WRITE.CPP
+++ b/SRC/WRITE.CPP
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <cctype>
 #include <ERROR/ERROR.H>
+#include <INPUT.H>
 
 static int get_font_chr(char c)
 {
@@ -176,7 +177,7 @@ void readline( int x, int y, int len, char *str, char *screen, bool (*filter_cha
 {
     int done = 0, a, dy;
     char *bg;
-    SDL_Scancode scancode;
+    tk_port::Input input;
     bg = (char *) malloc( 320 * f_y_size[FONT_NUM] );
     memcpy( bg, screen + x + (y * 320), 320 * f_y_size[FONT_NUM] );
     while (!done)
@@ -184,27 +185,27 @@ void readline( int x, int y, int len, char *str, char *screen, bool (*filter_cha
         writefonts2( x, y, str, 1 );
         for ( dy = 0; dy < f_y_size[FONT_NUM]; dy++ )
             memcpy( screen + x + ((dy + y) * 320), virbuff + x + ((dy + y) * 320), len * f_x_size[FONT_NUM] );
-        scancode = k::wait_for_keypress();
-        if ( scancode != k::ESC && scancode != k::BACKSPACE && scancode != k::ENTER )
+        input = k::wait_for_keypress();
+        if ( input != k::ESC && input != k::BACKSPACE && input != k::ENTER && input.get_type() == tk_port::Input::Keyboard )
             if ( (int)strlen( str ) < (len - 1))
             {
-                char key = k::scancode_to_char( scancode );
+                char key = k::scancode_to_char( input.scancode );
                 if ( filter_char( key ) )
                 {
                     str[strlen( str ) + 1] = 0;
                     str[strlen( str )] = key;
                 }
             }
-        if ( scancode == k::ESC )
+        if ( input == k::ESC )
         {
             str[0] = 0;
             done = 1;
         }
-        if ( scancode == k::ENTER )
+        if ( input == k::ENTER )
         {
             done = 1;
         }
-        if ( scancode == k::BACKSPACE )
+        if ( input == k::BACKSPACE )
         {
             if ( strlen( str ) > 0 )
                 str[strlen( str ) - 1] = 0;


### PR DESCRIPTION
Issue #102 (partial, to be splitted)

Emulate keyboard presses for at max two controllers. Controller keys need to be defined in options just like keyboard keys.

Limitations exist:
- Analog controllers not supported
  - Includes triggers
- Controllers are able to do only "player" interactions, so cannot move in menus etc.
  - Next iteration
- Primary and secondary controller assignment order is defined by  SDL
- ~Controller(s) need to be connected when game is started and controllers are not reconnected~

Both mappings tested separately with XBox One S controller. ~Two controllers not tested simultaneously due to lack of controllers.~ Good reason to invite a friend over with another controller.

![kuva](https://user-images.githubusercontent.com/24453333/50923994-f4e67e00-1456-11e9-8572-59360f2c9d08.png)

