### PR TITLE
Remove waiting of keypress when joining network game as client.

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2053,8 +2053,6 @@ int join_game(struct nodeaddr n)
     writefonts( 80, 90,buf, M_BLUE );
     writefonts( 80, 100,"done!", M_BLUE );
     memcpy(screen,virbuff,64000);
-    k::clear_stack();
-    k::wait_for_keypress();
 
     return 1;
 }


### PR DESCRIPTION
That feature has been removed since 1.2 beta. Tested with TK321 on DOSBox and it joins the game immeadiately without waiting for keypress.

Fixes issue #70 