### PR TITLE
Disallow enemies on network games.

### DIFF
--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -476,6 +476,13 @@ int deathmatch_options()
         if ( DEATH_MATCH_SPEED == 2 )
              strcpy(deathmatch_opt_text[1],"normal moving");
         else strcpy(deathmatch_opt_text[1],"fast moving");
+
+        // Enemies are not supported over network
+        if ( GAME_MODE == NETWORK )
+        {
+            ENEMIES_ON_GAME = 0;
+        }
+
         if ( ENEMIES_ON_GAME )
              strcpy(deathmatch_opt_text[2],"enemies on" );
         else strcpy(deathmatch_opt_text[2],"enemies off" );
@@ -523,7 +530,7 @@ int deathmatch_options()
             k::clear(k::ENTER);
             if ( selected == 0 ) { quit = 1;start = 1;}
             if ( selected == 1 ) DEATH_MATCH_SPEED = DEATH_MATCH_SPEED == 2 ? 3 : 2;
-            if ( selected == 2 ) ENEMIES_ON_GAME = ENEMIES_ON_GAME ? 0 : 1;
+            if ( selected == 2 ) ENEMIES_ON_GAME = GAME_MODE == NETWORK || ENEMIES_ON_GAME ? 0 : 1;
             if ( selected == 3 ) quit = 1;
 
         }


### PR DESCRIPTION
Issue #105 

Enemies are not supported over network.
Feature is now aligned with TK321.

Compared to TK321 with following scenario
- Player has enemies **enabled** in co-op game
- Player starts network game
  - Enemies get automatically **disabled** and cannot be enabled
- Player returns to local co-op game
  - Enemies are still **disabled** and player needs to manually enable them again

and the behavior is now same for the port.