### PR TITLE
Better level bounds checking (and developer QOL tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ New features:
 
 - Game controller support.
 
+- Setting the environment variable `TK_MUTE_MUSIC` mutes all music.
+  Useful if you like your Tapan Kaikki with your favorite mixtape.
+
 Bugfixes:
 
 - Many memory leaks and buffer overflows have been fixed.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ New features:
 - Setting the environment variable `TK_MUTE_MUSIC` mutes all music.
   Useful if you like your Tapan Kaikki with your favorite mixtape.
 
+- You can use the `-e` command line parameter to immediately jump
+  into single-player game in the given episode.  This works with
+  the `-l` switch too.  Mostly useful for development, of course.
+
 Bugfixes:
 
 - Many memory leaks and buffer overflows have been fixed.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ New features:
   into single-player game in the given episode.  This works with
   the `-l` switch too.  Mostly useful for development, of course.
 
+- Setting the environment variable `TK_SKIP_LEVEL_INFO` will skip the
+  screen that appears at the start of each level.  Useful for
+  impatient developers.
+
 Bugfixes:
 
 - Many memory leaks and buffer overflows have been fixed.

--- a/SRC/CLASSES.CPP
+++ b/SRC/CLASSES.CPP
@@ -404,17 +404,30 @@ void Player::change_weapon()
     load_cnt = 0;
 }
 
+// same behavior for Player and Enemy, but not going to bother giving them
+// a common superclass right now.
+static bool check_and_place_footprint(int footx, int footy) {
+    BLOCK *b = get_block_at_coord( footx, footy );
+    if ( b == nullptr || b->type != FLOOR )  // out of bounds, or wall
+    {
+        return false;
+    }
+    for ( int a = 0; a < DUST_BLOCKS; a++ )
+    {
+        if ( b->num == dust_blocks[a] )
+        {
+            new_effect( 0, FOOTPRINT, footx, footy, 0, 0 );
+            return true;
+        }
+    }
+    return false;
+}
+
 void Player::footprint( int side )
 {
-    int a, do_it = 0, footx, footy, footoffs;
-    footx = x + 15 + ( sini[( rangle2 + 90 + ( side*180 )  )  % 360]*4 );
-    footy = y + 15 + ( cosi[( rangle2 + 90 + ( side*180 )  )  % 360]*4 );
-    footoffs = ( footy / 20 ) *level_x_size + ( footx / 20 );
-    if ( level[footoffs].type == FLOOR )
-    for ( a = 0; a < DUST_BLOCKS &&do_it == 0; a ++  )
-    if ( level[footoffs].num == dust_blocks[a] ) do_it = 1;
-    if ( do_it )
-    new_effect( 0, FOOTPRINT, footx, footy, 0, 0 );
+    int footx = x + 15 + ( sini[( rangle2 + 90 + ( side*180 )  )  % 360]*4 );
+    int footy = y + 15 + ( cosi[( rangle2 + 90 + ( side*180 )  )  % 360]*4 );
+    check_and_place_footprint(footx, footy);
 }
 
 void Player::move( int angle, float spd, int index )
@@ -747,15 +760,9 @@ void Enemy::try_see_players()
 
 void Enemy::footprint( int side )
 {
-    int a, do_it = 0, footx, footy, footoffs;
-    footx = x + 15 + ( sini[( angle + 90 + ( side*180 )  )  % 360]*4 );
-    footy = y + 15 + ( cosi[( angle + 90 + ( side*180 )  )  % 360]*4 );
-    footoffs = ( footy / 20 ) *level_x_size + ( footx / 20 );
-    if ( level[footoffs].type == FLOOR )
-    for ( a = 0; a < DUST_BLOCKS &&do_it == 0; a ++  )
-    if ( level[footoffs].num == dust_blocks[a] ) do_it = 1;
-    if ( do_it )
-    new_effect( 0, FOOTPRINT, footx, footy, 0, 0 );
+    int footx = x + 15 + ( sini[( angle + 90 + ( side*180 )  )  % 360]*4 );
+    int footy = y + 15 + ( cosi[( angle + 90 + ( side*180 )  )  % 360]*4 );
+    check_and_place_footprint(footx, footy);
 }
 
 void Enemy::move( int angle, int spd )

--- a/SRC/CLASSES.CPP
+++ b/SRC/CLASSES.CPP
@@ -14,6 +14,7 @@
 #include "DRAW.H"
 #include "EFP/EFP.H"
 #include "FADE.H"
+#include "PORT_LEVEL.H"
 
 int ktexts=8;
 char killtexts[][MAX_MESSAGE_LENGTH-20]=
@@ -132,10 +133,10 @@ void Player::random_place()
         ret = 0;
         x = rand()  % level_x_size*20;
         y = rand()  % level_y_size*20;
-        if ( level[( int ) ( ( y / 20 ) *level_x_size + ( x / 20 )  ) ].type!= FLOOR ) ret = 1;
-        if ( level[( int ) ( ( ( y + size )  / 20 ) *level_x_size + ( x / 20 )  ) ].type!= FLOOR ) ret = 1;
-        if ( level[( int ) ( ( y / 20 ) *level_x_size + ( ( x + size )  / 20 )  ) ].type!= FLOOR ) ret = 1;
-        if ( level[( int ) ( ( ( y + size )  / 20 ) *level_x_size + ( ( x + size )  / 20 )  ) ].type!= FLOOR ) ret = 1;
+        if ( get_block_type_at_coord( x, y ) != FLOOR ) ret = 1;
+        if ( get_block_type_at_coord( x, y + size ) != FLOOR ) ret = 1;
+        if ( get_block_type_at_coord( x + size, y ) != FLOOR ) ret = 1;
+        if ( get_block_type_at_coord( x + size, y + size ) != FLOOR ) ret = 1;
         if ( ENEMIES_ON_GAME )
             for ( a = 0; a < ENEMIES && ret == 0; a++ )
                 if ( !enemy[a].DEAD )
@@ -388,7 +389,7 @@ void Effect::roll()
         {
             x += speed * sini[angle];
             y += speed * cosi[angle];
-            if ( level[(int) (y / 20) * level_x_size + (int) (x / 20)].type != FLOOR ) IN_USE = 0;
+            if ( get_block_type_at_coord(x, y) != FLOOR ) IN_USE = 0;
         }
         if ( IN_USE == 0 && type->index == BLOOD ) new_effect( 0, BLOOD2, x, y, 0, 0 );
     }
@@ -709,7 +710,7 @@ void Enemy::try_see_players()
         {
             rx = 14 + x + ( a*5*sini[angle_pl[b]] );
             ry = 14 + y + ( a*5*cosi[angle_pl[b]] );
-            if ( level[( ry / 20 ) *level_x_size + ( rx / 20 ) ].type!= FLOOR ) hit = 1;
+            if ( get_block_type_at_coord(rx, ry) != FLOOR ) hit = 1;
             if ( rx > player[b].x + 5 )
             if ( rx < player[b].x + 25 )
             if ( ry > player[b].y + 5 )
@@ -1026,7 +1027,7 @@ void Bullet::move()
         rx = x;
         ry = y;
         if ( type-> speed > 0 )
-        if ( level[ ( ry / 20 ) *level_x_size + ( rx / 20 ) ].type!= FLOOR )
+        if ( get_block_type_at_coord(rx, ry) != FLOOR )
         {
             kosh = 1;
         }

--- a/SRC/CLASSES.CPP
+++ b/SRC/CLASSES.CPP
@@ -283,32 +283,31 @@ void Player::chk_keys( int index )
 
 void Body_part::move()
 {
-    int offs[2*4]; //**
-    int reuna = 4; //**chk pointit on näin
-    int reuna2 = 4; //**
-    int rnx, rny; //**
-    float newx, newy;
-    newx = x + ( ( int ) speed*sini[angle] );
-    newy = y + ( ( int ) speed*cosi[angle] );
-    rnx = newx;
-    rny = newy;
-    if ( num < 12 )
-        if ( rand() % 3 != 0 ) new_effect( 0, BLOOD2, int( x ) + 10, int( y ) + 10, 0, 0 );
-    offs[0] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 10 - reuna2 )  / 20 );
-    offs[1] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 10 + reuna2 )  / 20 );
-    offs[2] = ( ( rny + 20 - reuna )  / 20 ) *level_x_size + ( ( rnx + 10 - reuna2 )  / 20 );
-    offs[3] = ( ( rny + 20 - reuna )  / 20 ) *level_x_size + ( ( rnx + 10 + reuna2 )  / 20 );
-    offs[4] = ( ( rny + 10 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[5] = ( ( rny + 10 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[6] = ( ( rny + 10 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + 20 - reuna )  / 20 );
-    offs[7] = ( ( rny + 10 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + 20 - reuna )  / 20 );
-    if ( newy < y && level[offs[0]].type == FLOOR && level[offs[1]].type == FLOOR )
+    int reuna = 4; //  * * chk pointit on näin
+    int reuna2 = 4; // * *
+    if ( num < 12 && rand() % 3 != 0 )
+    {
+        new_effect( 0, BLOOD2, int( x ) + 10, int( y ) + 10, 0, 0 );
+    }
+    float newx = x + ( ( int ) speed*sini[angle] );
+    float newy = y + ( ( int ) speed*cosi[angle] );
+    int rnx = newx;
+    int rny = newy;
+    int type0 = get_block_type_at_coord( rnx + 10 - reuna2, rny + reuna );
+    int type1 = get_block_type_at_coord( rnx + 10 + reuna2, rny + reuna );
+    int type2 = get_block_type_at_coord( rnx + 10 - reuna2, rny + 20 - reuna );
+    int type3 = get_block_type_at_coord( rnx + 10 + reuna2, rny + 20 - reuna );
+    int type4 = get_block_type_at_coord( rnx + reuna, rny + 10 - reuna2 );
+    int type5 = get_block_type_at_coord( rnx + reuna, rny + 10 + reuna2 );
+    int type6 = get_block_type_at_coord( rnx + 20 - reuna, rny + 10 - reuna2 );
+    int type7 = get_block_type_at_coord( rnx + 20 - reuna, rny + 10 + reuna2 );
+    if ( newy < y && type0 == FLOOR && type1 == FLOOR )
         y = newy;
-    if ( newy > y && level[offs[2]].type == FLOOR && level[offs[3]].type == FLOOR )
+    if ( newy > y && type2 == FLOOR && type3 == FLOOR )
         y = newy;
-    if ( newx < x && level[offs[4]].type == FLOOR && level[offs[5]].type == FLOOR )
+    if ( newx < x && type4 == FLOOR && type5 == FLOOR )
         x = newx;
-    if ( newx > x && level[offs[6]].type == FLOOR && level[offs[7]].type == FLOOR )
+    if ( newx > x && type6 == FLOOR && type7 == FLOOR )
         x = newx;
 }
 
@@ -420,12 +419,9 @@ void Player::footprint( int side )
 
 void Player::move( int angle, float spd, int index )
 {
-    int offs[2*4];   //  **
     int reuna = 6;   // *  * chk pointit on näin
     int reuna2 = 4;  // *  *
-    int rnx, rny;    //  **
     int crate_taken = 0;
-    float newx, newy;
     float speedi;
     int chk, a, b;
 
@@ -436,21 +432,22 @@ void Player::move( int angle, float spd, int index )
     if ( rand()  % 3 == 0 )
     new_effect( 0, BLOOD2, int( x )  + 15, int( y )  + 15, 0, 0 );
     speedi = spd;
-    newx = x + ( speedi*sini[angle] );
-    newy = y + ( speedi*cosi[angle] );
-    rnx = newx;
-    rny = newy;
-    offs[0] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 14 - reuna2 )  / 20 );
-    offs[1] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 14 + reuna2 )  / 20 );
-    offs[2] = ( ( rny + 28 - reuna )  / 20 ) *level_x_size + ( ( rnx + 14 - reuna2 )  / 20 );
-    offs[3] = ( ( rny + 28 - reuna )  / 20 ) *level_x_size + ( ( rnx + 14 + reuna2 )  / 20 );
-    offs[4] = ( ( rny + 14 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[5] = ( ( rny + 14 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[6] = ( ( rny + 14 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + 28 - reuna )  / 20 );
-    offs[7] = ( ( rny + 14 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + 28 - reuna )  / 20 );
+    float newx = x + ( speedi*sini[angle] );
+    float newy = y + ( speedi*cosi[angle] );
+    int rnx = newx;
+    int rny = newy;
+    int type0 = get_block_type_at_coord( rnx + 14 - reuna2, rny + reuna );
+    int type1 = get_block_type_at_coord( rnx + 14 + reuna2, rny + reuna );
+    int type2 = get_block_type_at_coord( rnx + 14 - reuna2, rny + 28 - reuna );
+    int type3 = get_block_type_at_coord( rnx + 14 + reuna2, rny + 28 - reuna );
+    int type4 = get_block_type_at_coord( rnx + reuna, rny + 14 - reuna2 );
+    int type5 = get_block_type_at_coord( rnx + reuna, rny + 14 + reuna2 );
+    int type6 = get_block_type_at_coord( rnx + 28 - reuna, rny + 14 - reuna2 );
+    int type7 = get_block_type_at_coord( rnx + 28 - reuna, rny + 14 + reuna2 );
+
     if ( newy < y )
-    if ( level[offs[0]].type == FLOOR )
-    if ( level[offs[1]].type == FLOOR )
+    if ( type0 == FLOOR )
+    if ( type1 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( !enemy[a].DEAD )
@@ -469,8 +466,8 @@ void Player::move( int angle, float spd, int index )
         if ( !chk ) y = newy;
     }
     if ( newy > y )
-    if ( level[offs[2]].type == FLOOR )
-    if ( level[offs[3]].type == FLOOR )
+    if ( type2 == FLOOR )
+    if ( type3 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( !enemy[a].DEAD )
@@ -489,8 +486,8 @@ void Player::move( int angle, float spd, int index )
         if ( !chk ) y = newy;
     }
     if ( newx < x )
-    if ( level[offs[4]].type == FLOOR )
-    if ( level[offs[5]].type == FLOOR )
+    if ( type4 == FLOOR )
+    if ( type5 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( !enemy[a].DEAD )
@@ -509,8 +506,8 @@ void Player::move( int angle, float spd, int index )
         if ( !chk ) x = newx;
     }
     if ( newx > x )
-    if ( level[offs[6]].type == FLOOR )
-    if ( level[offs[7]].type == FLOOR )
+    if ( type6 == FLOOR )
+    if ( type7 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( !enemy[a].DEAD )
@@ -763,7 +760,6 @@ void Enemy::footprint( int side )
 
 void Enemy::move( int angle, int spd )
 {
-    int offs[2*4];
     int reuna = 6; // päächk pointien etäisyys reunasta
     int reuna2 = 4; // sivu chk pointien etäisyys päächk pointeista
     int rnx, rny, speedi, chk, a;
@@ -780,18 +776,18 @@ void Enemy::move( int angle, int spd )
     newy = y + ( speedi*cosi[angle] );
     rnx = newx;
     rny = newy;
-    offs[0] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 14 - reuna2 )  / 20 );
-    offs[1] = ( ( rny + reuna )  / 20 ) *level_x_size + ( ( rnx + 14 + reuna2 )  / 20 );
-    offs[2] = ( ( rny + 28 - reuna )  / 20 ) *level_x_size + ( ( rnx + 14 - reuna2 )  / 20 );
-    offs[3] = ( ( rny + 28 - reuna )  / 20 ) *level_x_size + ( ( rnx + 14 + reuna2 )  / 20 );
-    offs[4] = ( ( rny + 14 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[5] = ( ( rny + 14 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + reuna )  / 20 );
-    offs[6] = ( ( rny + 14 - reuna2 )  / 20 ) *level_x_size + ( ( rnx + 28 - reuna )  / 20 );
-    offs[7] = ( ( rny + 14 + reuna2 )  / 20 ) *level_x_size + ( ( rnx + 28 - reuna )  / 20 );
-    chk = 0;
+    int type0 = get_block_type_at_coord((rnx + 14 - reuna2), (rny + reuna));
+    int type1 = get_block_type_at_coord((rnx + 14 + reuna2), (rny + reuna));
+    int type2 = get_block_type_at_coord((rnx + 14 - reuna2), (rny + 28 - reuna));
+    int type3 = get_block_type_at_coord((rnx + 14 + reuna2), (rny + 28 - reuna));
+    int type4 = get_block_type_at_coord((rnx + reuna), (rny + 14 - reuna2));
+    int type5 = get_block_type_at_coord((rnx + reuna), (rny + 14 + reuna2));
+    int type6 = get_block_type_at_coord((rnx + 28 - reuna), (rny + 14 - reuna2));
+    int type7 = get_block_type_at_coord((rnx + 28 - reuna), (rny + 14 + reuna2));
+
     if ( newy < y )
-    if ( level[offs[0]].type == FLOOR )
-    if ( level[offs[1]].type == FLOOR )
+    if ( type0 == FLOOR )
+    if ( type1 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( &enemy[a]!= this )
@@ -809,10 +805,10 @@ void Enemy::move( int angle, int spd )
         if ( rny + reuna < player[a].y + 28 - reuna ) chk = 1;
         if ( !chk ) y = newy;
     }
-    chk = 0;
+
     if ( newy > y )
-    if ( level[offs[2]].type == FLOOR )
-    if ( level[offs[3]].type == FLOOR )
+    if ( type2 == FLOOR )
+    if ( type3 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( &enemy[a]!= this )
@@ -830,10 +826,10 @@ void Enemy::move( int angle, int spd )
         if ( rny + 28 - reuna < player[a].y + 28 - reuna ) chk = 1;
         if ( !chk ) y = newy;
     }
-    chk = 0;
+
     if ( newx < x )
-    if ( level[offs[4]].type == FLOOR )
-    if ( level[offs[5]].type == FLOOR )
+    if ( type4 == FLOOR )
+    if ( type5 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( &enemy[a]!= this )
@@ -851,10 +847,10 @@ void Enemy::move( int angle, int spd )
         if ( rny + 15 < player[a].y + 30 ) chk = 1;
         if ( !chk ) x = newx;
     }
-    chk = 0;
+
     if ( newx > x )
-    if ( level[offs[6]].type == FLOOR )
-    if ( level[offs[7]].type == FLOOR )
+    if ( type6 == FLOOR )
+    if ( type7 == FLOOR )
     {
         for ( chk = 0, a = 0; a < ENEMIES; a ++  )
         if ( &enemy[a]!= this )

--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -20,6 +20,7 @@
 #define INCENDIARY 2
 #define FLOOR 0 // blockki tyyppejä
 #define WALLS 1
+#define OUTOFBOUNDS 0xFF
 #define MAX_ENEMIES 100  // max amount of enemies in game
 #define MAX_BODY_PARTS 300 // max amount of bodyparts in game
 #define MAX_EFFECTS 300  // max amount of effects in game

--- a/SRC/DRAW.CPP
+++ b/SRC/DRAW.CPP
@@ -7,8 +7,9 @@
 #include "GLOBVAR.H"
 #include "CLASSES.H"
 #include "WRITE.H"
+#include "PORT_LEVEL.H"
 
- // 20 x 20
+// 20 x 20
 void draw_block( int x, int y, int type, int num, int mode )
 {
     int a, offs;
@@ -905,7 +906,7 @@ void draw_targets()
             x += sini[aplayer[0]->rangle2];
             y += cosi[aplayer[0]->rangle2];
         }
-        if ( a == dist ||level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == WALLS ) draw_target( x - 3 - aplayer[0]->scr_x, y - 3 - aplayer[0]->scr_y, 0 );
+        if ( a == dist || get_block_type_at_coord(x, y) == WALLS ) draw_target( x - 3 - aplayer[0]->scr_x, y - 3 - aplayer[0]->scr_y, 0 );
     }
     if ( GAME_MODE == SPLIT_SCREEN )
     {
@@ -923,7 +924,7 @@ void draw_targets()
                 x += sini[aplayer[0]->rangle2];
                 y += cosi[aplayer[0]->rangle2];
             }
-            if ( a == dist ||level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == WALLS ) draw_target( x - 3 - aplayer[0]->scr_x, y - 3 - aplayer[0]->scr_y, 1 );
+            if ( a == dist || get_block_type_at_coord(x, y) == WALLS ) draw_target( x - 3 - aplayer[0]->scr_x, y - 3 - aplayer[0]->scr_y, 1 );
         }
         if ( !aplayer[1]->DEAD )
         if ( weapon[aplayer[1]->curr_weapon].gun )
@@ -939,7 +940,7 @@ void draw_targets()
                 x += sini[aplayer[1]->rangle2];
                 y += cosi[aplayer[1]->rangle2];
             }
-            if ( a == dist ||level[( int ) ( y / 20 ) *level_x_size + ( int ) ( x / 20 ) ].type == WALLS ) draw_target( x - 3 - aplayer[1]->scr_x + 160, y - 3 - aplayer[1]->scr_y, 2 );
+            if ( a == dist || get_block_type_at_coord(x, y) == WALLS ) draw_target( x - 3 - aplayer[1]->scr_x + 160, y - 3 - aplayer[1]->scr_y, 2 );
         }
     }
 }

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2647,42 +2647,52 @@ void logo()
     tk_port::event_tick();
 }
 
-int main( int argc, char *argv[] )
+static void parse_cmdline( int argc, char *argv[], int *pause )
 {
-    int a = 0, b;
-    int pause = 0;
-    for ( a = 1; a < argc; a ++  )
+    int b;
+    for ( int a = 1; a < argc; a++ )
     {
         strupr( argv[a] );
-        if ( ( argv[a][0] == '-')||( argv[a][0] == '/'))
-        switch( argv[a][1] )
-        {
-            case 'F':b = atoi( argv[ ++ a] );
-                     if ( b >= 30 &&b <= 500 ) target_frames = b;
-                     break;
-            case 'L':b = atoi( argv[ ++ a] );
-                     if ( b > 0 ) START_LEVEL = b - 1;
-                     break;
-            case 'P':pause = 1;
-                     break;
-            case 'M':SHOW_ENEMIES = 1;
-                     break;
-            case 'H':case '?':
-                     std::cout << std::endl;
-                     std::cout << "Ultimate Tapan Kaikki " << Version << std::endl;
-                     std::cout << "Compiled at "<< __DATE__<< ' ' << __TIME__ << std::endl;
-                     std::cout << "parameters:" << std::endl;
-                     std::cout << "-?,-h this help"<< std::endl;
-                     std::cout << "-v    force mcga mode" << std::endl;
-                     std::cout << "-p    pause at startup" << std::endl;
-                     std::cout << "-m    show enemies on map" << std::endl;
-                     std::cout << "-l ## start at level ##" << std::endl;
-                     std::cout << "-f ## set gamespeed to ## fps (def. 40)" << std::endl;
-                     std::cout << std::endl;
-                     exit( 1 );
-                     break;
-        }
+        if ((argv[a][0] == '-') || (argv[a][0] == '/'))
+            switch (argv[a][1])
+            {
+                case 'F':
+                    b = atoi( argv[++a] );
+                    if ( b >= 30 && b <= 500 ) target_frames = b;
+                    break;
+                case 'L':
+                    b = atoi( argv[++a] );
+                    if ( b > 0 ) START_LEVEL = b - 1;
+                    break;
+                case 'P':
+                    *pause = 1;
+                    break;
+                case 'M':
+                    SHOW_ENEMIES = 1;
+                    break;
+                case 'H':
+                case '?':
+                    std::cout << std::endl;
+                    std::cout << "Ultimate Tapan Kaikki " << Version << std::endl;
+                    std::cout << "Compiled at " << __DATE__ << ' ' << __TIME__ << std::endl;
+                    std::cout << "parameters:" << std::endl;
+                    std::cout << "-?,-h this help" << std::endl;
+                    std::cout << "-v    force mcga mode" << std::endl;
+                    std::cout << "-p    pause at startup" << std::endl;
+                    std::cout << "-m    show enemies on map" << std::endl;
+                    std::cout << "-l ## start at level ##" << std::endl;
+                    std::cout << "-f ## set gamespeed to ## fps (def. 40)" << std::endl;
+                    std::cout << std::endl;
+                    exit( 1 );
+                    break;
+            }
     }
+}
+
+int main( int argc, char *argv[] )
+{
+    int pause = 0;
+    parse_cmdline(argc, argv, &pause);
     if(tk_port::init() != 0) {
         return 1;
     }

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2664,6 +2664,10 @@ static void parse_cmdline( int argc, char *argv[], int *pause )
                     b = atoi( argv[++a] );
                     if ( b > 0 ) START_LEVEL = b - 1;
                     break;
+                case 'E':
+                    b = atoi( argv[++a] );
+                    if ( b > 0 ) episode = b - 1;
+                    break;
                 case 'P':
                     *pause = 1;
                     break;
@@ -2681,6 +2685,7 @@ static void parse_cmdline( int argc, char *argv[], int *pause )
                     std::cout << "-p    pause at startup" << std::endl;
                     std::cout << "-m    show enemies on map" << std::endl;
                     std::cout << "-l ## start at level ##" << std::endl;
+                    std::cout << "-e ## immediately start single-player episode ##" << std::endl;
                     std::cout << "-f ## set gamespeed to ## fps (def. 40)" << std::endl;
                     std::cout << std::endl;
                     exit( 1 );
@@ -2692,6 +2697,7 @@ static void parse_cmdline( int argc, char *argv[], int *pause )
 int main( int argc, char *argv[] )
 {
     int pause = 0;
+    episode = INVALID_EPISODE;
     parse_cmdline(argc, argv, &pause);
     if(tk_port::init() != 0) {
         return 1;
@@ -2700,9 +2706,15 @@ int main( int argc, char *argv[] )
     do_all();
     i::clear_stack();
     if ( pause ) i::wait_for_keypress();
-    logo();
-    menu();
-    if ( ph ) MIDASstopModule( ph );
+    if(episode != INVALID_EPISODE) {  // set by parse_cmdline()
+        GAME_MODE = ONE_PLAYER;
+        KILLING_MODE = COOPERATIVE;
+        game();
+    } else {
+        logo();
+        menu();
+        if ( ph ) MIDASstopModule( ph );
+    }
     free_all();
     tk_port::deinit();
 //  credits();

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -36,6 +36,7 @@ struct packet *snd, *rec[RECEIVERS];
 #include "OPTIONS.H"
 #include "I_FUNCS.H" // paska funkkareita
 #include "MAKET_IN.H"
+#include "PORT_LEVEL.H"
 
 void menu_biisi()
 {
@@ -247,16 +248,11 @@ void free_all()
 int check_place( int x, int y, int size )
 {
     int a, ret = 0;
+    if ( get_block_type_at_coord( x, y ) != FLOOR ) return 1;
+    if ( get_block_type_at_coord( x + size, y ) != FLOOR ) return 1;
+    if ( get_block_type_at_coord( x, y + size ) != FLOOR ) return 1;
+    if ( get_block_type_at_coord( x + size, y + size ) != FLOOR ) return 1;
 
-    // Check that the object fits to level vertically...
-    if ( ( ( y + size ) / 20 ) >= level_y_size ) return 1;
-    // ... and horizontally
-    if ( ( ( x + size ) / 20 ) >= level_x_size ) return 1;
-
-    if ( level[( y / 20 ) *level_x_size + ( x / 20 ) ].type!= FLOOR ) ret = 1;
-    if ( level[( ( y + size )  / 20 ) *level_x_size + ( x / 20 ) ].type!= FLOOR ) ret = 1;
-    if ( level[( y / 20 ) *level_x_size + ( ( x + size )  / 20 ) ].type!= FLOOR ) ret = 1;
-    if ( level[( ( y + size )  / 20 ) *level_x_size + ( ( x + size )  / 20 ) ].type!= FLOOR ) ret = 1;
     for ( a = 0; a < ACTIVE_PLAYERS; a ++ )
         if ( get_dist( x, y, aplayer[a]->x, aplayer[a]->y ) < 50 ) ret = 1;
     return (ret);
@@ -265,29 +261,31 @@ int check_place( int x, int y, int size )
 void place_enemies()
 
 {
-    int a, done, nx = 0, ny = 0, b, c;
-    for ( a = 0; a < ENEMIES; a ++  )
+    for ( int a = 0; a < ENEMIES; a ++  )
     {
-        done = 0;
+        int tile_x = 0, tile_y = 0;
+        int done = 0;
         while ( done == 0 )
         {
-            nx = ( rand()  % ( level_x_size - 2 )  )  + 1;
-            ny = ( rand()  % ( level_y_size - 2 )  )  + 1;
-            if ( level[ny*level_x_size + nx].type == FLOOR )
+            tile_x = ( rand()  % ( level_x_size - 2 )  )  + 1;
+            tile_y = ( rand()  % ( level_y_size - 2 )  )  + 1;
+            if ( get_block_type_at_coord(tile_x * 20, tile_y * 20) == FLOOR )
             {
                 done = 1;
                 if ( a > 0 )
-                    for ( b = 0; b < a; b++ )
-                        if ( nx == enemy[b].x && ny == enemy[b].y ) done = 0;
-                for ( c = 0; c < ACTIVE_PLAYERS && done == 1; c++ )
-                    if ( get_dist( nx, ny, pl_start_x[c], pl_start_y[c] ) < 8 ) done = 0;
+                    for ( int b = 0; b < a; b++ )
+                        if ( tile_x == enemy[b].x && tile_y == enemy[b].y ) done = 0;
+                for ( int c = 0; c < ACTIVE_PLAYERS && done == 1; c++ )
+                    if ( get_dist( tile_x, tile_y, pl_start_x[c], pl_start_y[c] ) < 8 ) done = 0;
             }
         }
-        enemy[a].x = nx;
-        enemy[a].y = ny;
+        enemy[a].x = tile_x;
+        enemy[a].y = tile_y;
     }
-    for ( a = 0; a < ENEMIES; a ++  )
+
+    for ( int a = 0; a < ENEMIES; a ++  )
     {
+        // convert tile coordinates into pixel coordinates
         enemy[a].x = ( ( enemy[a].x*20 )  - 5 );
         enemy[a].y = ( ( enemy[a].y*20 )  - 5 );
         enemy[a].angle = rand()  % 360;

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2333,7 +2333,7 @@ void game()
             else {
                 leveldata.load( match_level );
             }
-            if ( KILLING_MODE != DEATHMATCH )
+            if ( KILLING_MODE != DEATHMATCH && !getenv("TK_SKIP_LEVEL_INFO") )
                 level_info();
         }
         if ( !BACK_TO_MENU )

--- a/SRC/PORT_LEVEL.CPP
+++ b/SRC/PORT_LEVEL.CPP
@@ -1,0 +1,24 @@
+#include "DEFINES.H"
+#include "TYPES.H"
+#include "GLOBVAR.H"
+
+/**
+ * Get the level block at level coordinate px,py. This is _not_ the tile coordinate!
+ * Returns null if out of bounds.
+ */
+BLOCK* get_block_at_coord( int px, int py ) {
+    int tx = px / 20;
+    int ty = py / 20;
+    if(tx < 0 || tx >= level_x_size) return nullptr;
+    if(ty < 0 || ty >= level_y_size) return nullptr;
+    return &level[ty * level_x_size + tx];
+}
+
+/**
+ * Get the tile type at coordinate px / py. This is _not_ the tile coordinate!
+ * This may also return OUTOFBOUNDS if the coordinate is out of bounds.
+ */
+int get_block_type_at_coord( int px, int py ) {
+    BLOCK *b = get_block_at_coord(px, py);
+    return (b != nullptr ? b->type : OUTOFBOUNDS);
+}

--- a/SRC/PORT_LEVEL.H
+++ b/SRC/PORT_LEVEL.H
@@ -1,0 +1,7 @@
+#ifndef ULTIMATETAPANKAIKKI_PORT_LEVEL_H
+#define ULTIMATETAPANKAIKKI_PORT_LEVEL_H
+#include "DEFINES.H"
+BLOCK* get_block_at_coord( int px, int py );
+int get_block_type_at_coord( int px, int py );
+
+#endif //ULTIMATETAPANKAIKKI_PORT_LEVEL_H

--- a/SRC/SOUND.CPP
+++ b/SRC/SOUND.CPP
@@ -172,6 +172,9 @@ MIDASmodulePlayHandle MIDASplayModule( MIDASmodule module, int loopSong )
 {
     if (!started) return 0;
     Mix_HaltMusic();
+    if (getenv("TK_MUTE_MUSIC")) {
+        return 1;
+    }
     if ( Mix_PlayMusic( module->mix_music, loopSong ? -1 : 0 ) != 0 )
     {
         SDL_Log( "Error playing music:  %s", Mix_GetError());


### PR DESCRIPTION
* Replaces error-prone direct `level[y * w + x]` accesses with a helper function
* Adds `TK_MUTE_MUSIC` (it was interrupting my Spotify, grump grump)
* Adds `tk3 -e 1 -l 1` + `TK_SKIP_LEVEL_INFO` for immediate debug fun

Probably fixes #122.