### PR TITLE
Static Windows runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(${PROJECT_BINARY_DIR})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if (WIN32)
-	add_compile_options(/WX /wd4244 /wd4996)
+	add_compile_options(/MT /WX /wd4244 /wd4996)
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsigned-char -Wall -Wno-pedantic -Wsign-compare")
 endif()


### PR DESCRIPTION
Build Visual C++ runtime statically into the executable.                                                                                                                                                                                                                                                                                                                                                    Avoid redistributing separate runtime DLLs or mandating full runtime installation.

https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2017

**Note**: Version 1 release was built with this flag.