### PR TITLE
Force brew update to avoid "outdated" error in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
       - sdl2_mixer
       - sdl2_image
       - sdl2_net
+    update: true
 
 before_install:
   - |


### PR DESCRIPTION
Fix dependency installation failure on OSX builds.

```
Error: Your Homebrew is outdated. Please run `brew update`.
Error: Kernel.exit
```