### PR TITLE
Force network clients to Deathmatch mode

### DIFF
--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -9,7 +9,7 @@
 #define Remark
 #endif
 
-#define Version "v1.21+sp2" Remark
+#define Version "v1.21+sp3 SNAPSHOT" Remark
 #define pi 3.14159265358979
 #define CRATE_WAKE_UP_COUNT 500 // = 12.5 secs if 40 frames per sec
 #define MESSAGE_TIME_ON_SCREEN 200  // = 5 secs if 40 frames per sec

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -699,6 +699,10 @@ void multiplayer_options()
                 GAME_MODE = NETWORK;
                 NETWORK_MODE = CLIENT;
 
+                // Online games are always Deathmatch, make sure
+                // potential active COOPERATIVE mode is overridden
+                KILLING_MODE = DEATHMATCH;
+
                 setup_ipx();
                 save_options();
                 if (select_server()) game();


### PR DESCRIPTION
(Partially) issue https://github.com/suomipelit/ultimatetapankaikki/issues/141

Force network clients to Deathmatch mode while joining. Fixes an issue where client had Cooperative mode selected while joining an online game and game misbehaves. Online games are always Deathmatch.

Bump version number to "SP3 SNAPSHOT" since this is a behavior change compared to SP2.