### PR TITLE
Manual Emscripten yield + optimize screen drawing

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2436,8 +2436,13 @@ void game()
                     Spot_count += 2;
                     Spot_count%= 360;
                     frame_count ++;
+                    tk_port::event_tick();
                 }
-                tk_port::event_tick();
+                else
+                {
+                    // No need to draw screen, just poll events
+                    tk_port::event_tick( false );
+                }
 
                 if ( tk_port::quit_flag )
                 {

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -205,6 +205,9 @@ int init()
 {
     int ret;
     read_tk_port_debug();
+#ifdef TK_PORT_EMCC
+    SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
+#endif
     if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER ) != 0 )
     {
         SDL_Log( "Error initializing SDL:  %s", SDL_GetError());
@@ -332,10 +335,15 @@ void frame_rate_limiter( const unsigned int max_fps )
     const unsigned int since_last_frame = SDL_GetTicks() - frame_start_time;
     const unsigned int delay = clamp( max_delay - since_last_frame, 0, max_delay );
 
+#ifdef TK_PORT_EMCC
+    // Yield control to the browser even if delay == 0
+    emscripten_sleep(delay);
+#else
     if ( delay > 0 )
     {
         SDL_Delay( delay );
     }
+#endif
 
     frame_start_time = SDL_GetTicks();
 }

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -348,7 +348,7 @@ void frame_rate_limiter( const unsigned int max_fps )
     frame_start_time = SDL_GetTicks();
 }
 
-void event_tick( void )
+void event_tick( bool draw_screen )
 {
     SDL_Event e;
     while (SDL_PollEvent( &e ))
@@ -379,7 +379,11 @@ void event_tick( void )
                 break;
         }
     }
-    present_screen();
+
+    if (draw_screen)
+    {
+        present_screen();
+    }
 
     // To avoid running in busy loop taking all the CPU time,
     // limit the speed to nice multiple of target frame rate

--- a/SRC/PORT.H
+++ b/SRC/PORT.H
@@ -28,7 +28,7 @@ int init( void );
 
 void deinit( void );
 
-void event_tick( void );
+void event_tick( bool draw_screen = true );
 
 void change_resolution( const unsigned int y );
 


### PR DESCRIPTION
- Yield control to the browser by manually calling `emscripten_sleep()` instead of letting SDL do it.
- Don't present the screen if nothing has changed. This gives better performance, as about 3 of 4 screen draws are skipped.