### PR TITLE
Reduce network latency and traffic

### DIFF
--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -88,4 +88,7 @@
 #define WOOSHWAV 9
 #define FLAMEWAV 10
 
+#define KEEPALIVE_INTERVAL_MS 1000
+#define KEEPALIVE_TIMEOUT_MS 3000
+
 #endif

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -1396,7 +1396,7 @@ void server_add_player(char *name,struct nodeaddr *n)
     player[a].player_kills=0;
     player[a].color=colors[a];
     player[a].death_match_start_up();
-    player[a].time_since_last_alive=0;
+    player[a].time_since_last_alive=tk_port::get_time_ms();
 
     sendipxnow(n,IPX_GAMEDATA,(int)a);
     for (b=1;b<MAX_PLAYERS;b++)
@@ -1434,7 +1434,7 @@ void do_server_shit()
                 pcom[pcoms++]=data;
                 pl=rec[a]->data[ofs++];
                 player[pl].enabled=1;
-                player[pl].time_since_last_alive=0;
+                player[pl].time_since_last_alive=tk_port::get_time_ms();
                 break;
 
                 case IPX_MESSAGE:
@@ -1850,7 +1850,13 @@ void do_client_shit()
             };
         }
     }
-    sendipx(0,IPX_ALIVE);
+
+    const uint32_t time_now_ms = tk_port::get_time_ms();
+    if (time_now_ms - client_keep_alive_time_ms >= KEEPALIVE_INTERVAL_MS)
+    {
+        client_keep_alive_time_ms = time_now_ms;
+        sendipx(0, IPX_ALIVE);
+    }
     flushipx();
 }
 
@@ -2220,7 +2226,7 @@ void chk_for_loosers()
 
     for (a=1;a<MAX_PLAYERS;a++)
      if (player[a].enabled)
-      if (player[a].time_since_last_alive++>=40*3)
+      if (tk_port::get_time_ms() - player[a].time_since_last_alive >= KEEPALIVE_TIMEOUT_MS)
        {
         player[a].enabled=0;
         sprintf(message,"%s (%d) left the game",player[a].name,player[a].tindex);
@@ -2413,23 +2419,6 @@ void game()
                     OVER_POWER = ( op[0] + op[1] + op[2] + op[3] + op[4] ) / op_table_size;
                     }
                     framecount = 0;// incremented by MIDAS timer
-
-                    if ( GAME_MODE == NETWORK )
-                    {
-                        switch ( NETWORK_MODE )
-                        {
-                        case CLIENT:
-                            do_client_shit();
-                            break;
-                        case SERVER:
-                            chk_for_loosers();
-                            do_server_shit();
-                            break;
-                        default:
-                            error( "Invalid network mode" );
-                        }
-                    }
-
                     game_shit();// do the game !!!!
 
                     Steam_count ++;
@@ -2443,6 +2432,22 @@ void game()
                 {
                     // No need to draw screen, just poll events
                     tk_port::event_tick( false );
+                }
+
+                if (GAME_MODE == NETWORK)
+                {
+                    switch (NETWORK_MODE)
+                    {
+                    case CLIENT:
+                        do_client_shit();
+                        break;
+                    case SERVER:
+                        chk_for_loosers();
+                        do_server_shit();
+                        break;
+                    default:
+                        error("Invalid network mode");
+                    }
                 }
 
                 if ( tk_port::quit_flag )

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2413,7 +2413,6 @@ void game()
                     OVER_POWER = ( op[0] + op[1] + op[2] + op[3] + op[4] ) / op_table_size;
                     }
                     framecount = 0;// incremented by MIDAS timer
-                    game_shit();// do the game !!!!
 
                     if ( GAME_MODE == NETWORK )
                     {
@@ -2430,6 +2429,8 @@ void game()
                             error( "Invalid network mode" );
                         }
                     }
+
+                    game_shit();// do the game !!!!
 
                     Steam_count ++;
                     Steam_count%= 360;

--- a/SRC/GLOBVAR.CPP
+++ b/SRC/GLOBVAR.CPP
@@ -3,6 +3,7 @@
 #include "TYPES.H"
 #include "CLASSES.H"
 #include <ctime>
+#include <cstdint>
 #include "INPUT/KEYB.H"
 #include "SOUND.H"
 #include "PORT_TEXT.H"
@@ -439,3 +440,4 @@ vile filelist[256][1024];
 vile dirlist[256];
 int files_in_episode[256];
 int dirs = 0;
+uint32_t client_keep_alive_time_ms = 0;

--- a/SRC/GLOBVAR.H
+++ b/SRC/GLOBVAR.H
@@ -91,4 +91,5 @@ extern vile filelist[256][1024];
 extern vile dirlist[256];
 extern int files_in_episode[256];
 extern int dirs;
+extern uint32_t client_keep_alive_time_ms;
 #endif

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -459,6 +459,11 @@ void toggle_fullscreen()
     window_resized = true;
 }
 
+uint32_t get_time_ms()
+{
+    return SDL_GetTicks();
+}
+
 /**
  * Return the wallclock time vintage_clock() is derived off.
  * @return

--- a/SRC/PORT.H
+++ b/SRC/PORT.H
@@ -42,6 +42,8 @@ int vintage_clock( void );
 
 void toggle_fullscreen( void );
 
+uint32_t get_time_ms();
+
 extern bool quit_flag;
 extern uint32_t debug;
 }


### PR DESCRIPTION
In original version network code was executed outside of game loop at unrestricted speed. Due to speed of modern computers, that's no longer a good idea since it leads to huge network traffic. Port synced network code speed to game logic.

However we have since implemented a speed limitter (160 Hz) so this PR moves the network refresh to be executed quicker than game logic to lessen latency.

Client logic was changed to send the keep-alive once per second.