### PR TITLE
Close client socket on keep-alive timeout

### DIFF
--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -2231,6 +2231,7 @@ void chk_for_loosers()
           sendipx(b, IPX_PLAYERDISCONNECTED, (char) a);
          }
         message_board.add_message(message);
+        tk_port::net::disconnect(player[a].node);
        }
 }
 

--- a/SRC/NET/NET.CPP
+++ b/SRC/NET/NET.CPP
@@ -74,16 +74,15 @@ bool active_connections_exist()
     return transport::is_connected();
 }
 
-static void disconnect(const unsigned int index)
+void disconnect(struct nodeaddr destnode)
 {
     // Disconnect is not propagated to game logic but
     // server relies on ALIVE messages. It then propagates
-    // disconnects to clients with
-    // PLAYERDISCONNECTED message.
+    // disconnects to clients with PLAYERDISCONNECTED message.
 
-    storages[index].clear();
+    storages[destnode.node].clear();
 
-    return transport::disconnect(index);
+    return transport::disconnect(destnode.node);
 }
 
 // Very simple checksum for packet sanity check
@@ -128,7 +127,7 @@ static void receive_to_storage(const unsigned int index)
         break;
     }
     case transport::DISCONNECTED:
-        disconnect(index);
+        disconnect({ index });
         break;
     default:
         break;
@@ -217,11 +216,11 @@ void sendpacket(struct nodeaddr destnode, struct packet *packetet, word len)
 
     if (destnode.node == BROADCAST_ID)
     {
-        transport::broadcast(packet, [](transport::Identifier index) { disconnect(index); });
+        transport::broadcast(packet, [](transport::Identifier index) { disconnect({ index }); });
     }
     else if (!transport::send(destnode.node, packet))
     {
-        disconnect(destnode.node);
+        disconnect(destnode);
     }
 }
 }

--- a/SRC/NET/NET.H
+++ b/SRC/NET/NET.H
@@ -40,6 +40,8 @@ void accept_connections();
 
 bool active_connections_exist();
 
+void disconnect(struct nodeaddr destnode);
+
 bool receive(struct packet *buffer);
 void sendpacket(struct nodeaddr destnode, struct packet *packetet, word len);
 

--- a/SRC/NET/TRANSPORT/SDL/TRANSPORT.CPP
+++ b/SRC/NET/TRANSPORT/SDL/TRANSPORT.CPP
@@ -140,8 +140,8 @@ void close_connections()
     {
         if (socket != nullptr)
         {
-            SDLNet_TCP_DelSocket(set, socket);
             SDLNet_TCP_Close(socket);
+            SDLNet_TCP_DelSocket(set, socket);
         }
     }
 
@@ -181,6 +181,7 @@ bool is_connected()
 
 void disconnect(Identifier index)
 {
+    SDLNet_TCP_Close(sockets[index]);
     SDLNet_TCP_DelSocket(set, sockets[index]);
     sockets[index] = nullptr;
 }


### PR DESCRIPTION
Close client socket on server side if keep-alive timeouts. Disconnects client correctly from server.

Partial fix to #141.

Unrelated: Fix socket deletion order. Close before delete.