### PR TITLE
Fix small sprite loading buffer overflow

### DIFF
--- a/SRC/PORT_IMAGE.CPP
+++ b/SRC/PORT_IMAGE.CPP
@@ -92,7 +92,7 @@ bool load_png( const char *png_name, char *kuva, char *paletti, int *width, int 
             {
                 size_t in_off = y * image->pitch;
                 size_t out_off = y * image->w;
-                memcpy( kuva + out_off, ( const char* ) image->pixels + in_off, image->pitch );
+                memcpy( kuva + out_off, ( const char* ) image->pixels + in_off, image->w );
             }
         }
         else


### PR DESCRIPTION
Crosshair and bomb sprites are 7x7 and hence 49 bytes are reserved for their data. Those images have pitch of 8 - but only 7 bytes should be copied to avoid writing extra byte after every row. At last row it means that buffer overflow of 1 byte happens.