### PR TITLE
Fix WebRTC networking on Firefox

### DIFF
--- a/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
+++ b/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
@@ -94,7 +94,7 @@ const libraryWEBRTC = {
         const handler = message => {
           if (messageTypes.includes(message.type)) {
             done(message);
-          } else if (message.type === error) {
+          } else if (message.type === 'error') {
             fail(new Error(message.reason));
           } else {
             console.log('Ignoring unexpected message:', message);
@@ -307,8 +307,8 @@ const libraryWEBRTC = {
           }
         }
         wakeup(0);
-      } catch (error) {
-        console.error('Error joining game:', error.message);
+      } catch (err) {
+        console.error('Error joining game');
         WEBRTC.ws.close();
         WEBRTC.ws = null;
         wakeup(1);

--- a/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
+++ b/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
@@ -145,11 +145,13 @@ const libraryWEBRTC = {
       });
       if (WEBRTC.mode === 'server') {
         const dataChannel = pc.createDataChannel('data');
+        dataChannel.binaryType = 'arraybuffer';
         dataChannel.addEventListener('open', () => {
           WEBRTC.setupDataChannel(peer, dataChannel);
         });
       } else {
         pc.addEventListener('datachannel', event => {
+          event.channel.binaryType = 'arraybuffer';
           WEBRTC.setupDataChannel(peer, event.channel);
           WEBRTC.dispatchMessage({ type: 'connected' })
         });


### PR DESCRIPTION
RTCDataChannel's default binary type seems to be arraybuffer on Chrome, but Firefox has "blob". This broke message decoding.
