### PR TITLE
Persistent options for web port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 	set(USE_FLAGS "-O3 -s TOTAL_MEMORY=32MB -s ASYNCIFY -s ASYNCIFY_IMPORTS='[\"webrtc_create_server\", \"webrtc_connect_to_server\"]' -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s USE_SDL_MIXER=2 -s USE_SDL_NET=2 -s SDL2_IMAGE_FORMATS='[\"png\"]' --js-library SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS --preload-file FNTS/ --preload-file EFPS/ --preload-file LEVS/ --preload-file WAVS/ --preload-file MUSIC_OGG/ --preload-file OPTIONS.CFG --shell-file SRC/WEB/shell.html")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS}")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${USE_FLAGS}")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${USE_FLAGS}")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${USE_FLAGS} -lidbfs.js")
 	set(CMAKE_EXECUTABLE_SUFFIX .html)
 endif()
 

--- a/SRC/MISCFUNC.CPP
+++ b/SRC/MISCFUNC.CPP
@@ -653,12 +653,13 @@ std::string data_path( const std::string& pathname )
 
 std::string config_path( const std::string& pathname )
 {
-    const char *XDG_DATA_HOME;
-    const char *HOME;
     std::string result;
 
-    XDG_DATA_HOME = getenv( "XDG_DATA_HOME" );
-    HOME = getenv( "HOME" );
+#ifdef TK_PORT_EMCC
+    result += "/persistent";
+#else
+    const char *XDG_DATA_HOME = getenv( "XDG_DATA_HOME" );
+    const char *HOME = getenv( "HOME" );
 
     if ( XDG_DATA_HOME )
     {
@@ -668,6 +669,7 @@ std::string config_path( const std::string& pathname )
     {
         result += std::string(HOME) + "/.config/ultimatetapankaikki";
     }
+#endif
 
     if ( pathname.size() )
     {
@@ -699,9 +701,14 @@ std::string home_path( const std::string& pathname )
 // Returns 1 if config directory doesn't exist and cannot be created
 int ensure_config_dir_exists()
 {
+#ifdef TK_PORT_EMCC
+    // Created in port initialization as it needs to be mounted for read access too
+    return 0;
+#else
     int status = mkdir( config_path().c_str(),
                         S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH );
     return status != 0 && errno != EEXIST ? 1 : 0;
+#endif
 }
 #endif
 

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -50,6 +50,8 @@ void save_options()
     fwrite( &saved_killing_mode, sizeof( saved_killing_mode ), 1, cfg );
     fwrite( &saved_game_mode, sizeof( saved_game_mode ), 1, cfg );
     fclose( cfg );
+
+    tk_port::flush_fs();
 }
 
 void load_options()

--- a/SRC/PORT.CPP
+++ b/SRC/PORT.CPP
@@ -25,6 +25,10 @@ uint64_t timer_zero;
 bool full_screen = false;
 Controllers *controllers = NULL;
 
+#ifdef TK_PORT_EMCC
+bool fs_mounted = false;
+#endif
+
 #define TK_PORT_NSEC_PER_SEC 1000000000L
 #define TK_PORT_NSEC_PER_MSEC 1000000L
 #define TK_PORT_GRAPHICS_SCALE 3
@@ -201,11 +205,39 @@ void change_resolution( const unsigned int y )
 
     init_screen();
 }
+
+#ifdef TK_PORT_EMCC
+extern "C"
+{
+EMSCRIPTEN_KEEPALIVE
+void mount_ready()
+{
+    fs_mounted = true;
+}
+}
+
+void mount_fs()
+{
+    // Directory created here instead of ensure_config_dir_exists because
+    // it needs to be done for read access too
+    EM_ASM(
+        FS.mkdir('/persistent');
+        FS.mount(IDBFS, {}, '/persistent');
+        FS.syncfs(true, function (err) {
+            ccall('mount_ready', 'v');
+        });
+    );
+
+    while (!fs_mounted) sleep(1);
+}
+#endif
+
 int init()
 {
     int ret;
     read_tk_port_debug();
 #ifdef TK_PORT_EMCC
+    mount_fs();
     SDL_SetHint(SDL_HINT_EMSCRIPTEN_ASYNCIFY, "0");
 #endif
     if ( SDL_Init( SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER ) != 0 )
@@ -462,6 +494,16 @@ void toggle_fullscreen()
 uint32_t get_time_ms()
 {
     return SDL_GetTicks();
+}
+
+void flush_fs()
+{
+#ifdef TK_PORT_EMCC
+    EM_ASM(
+        FS.syncfs(function (err) {
+        });
+    );
+#endif
 }
 
 /**

--- a/SRC/PORT.H
+++ b/SRC/PORT.H
@@ -44,6 +44,8 @@ void toggle_fullscreen( void );
 
 uint32_t get_time_ms();
 
+void flush_fs();
+
 extern bool quit_flag;
 extern uint32_t debug;
 }


### PR DESCRIPTION
Issue #145 

Use [Indexed Database](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs) for storing options persistently.

Database is mounted at `/persistent` for read and write access. It needs to be done in port init and synchronized so that option reading works correctly.

Edit: [Now live.](https://suomipelit.github.io/ultimatetapankaikki-web/)