### PR TITLE
Prompt player name for network games and keep name with ESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ New features:
   screen that appears at the start of each level.  Useful for
   impatient developers.
 
+- Name is not cleared if pressing ESC in name prompt.
+
+- Player name is prompted if starting or joining to network game with
+  default name.
+
 Bugfixes:
 
 - Many memory leaks and buffer overflows have been fixed.

--- a/SRC/MISCFUNC.CPP
+++ b/SRC/MISCFUNC.CPP
@@ -38,7 +38,7 @@ bool filter_name_char( char c )
     return ( 'a' <= c && c <= 'z' ) || ( '0' <= c && c <= '9' ) || c == ' ' || c == '.';
 }
 
-void change_name( int num )
+void change_name( int num, bool fade_out )
 {
     int x;
     fadeout( virbuff, pal );
@@ -54,7 +54,8 @@ void change_name( int num )
         readline( x, 100, 10, name1, screen, filter_name_char );
     if ( num == 2 )
         readline( x, 100, 10, name2, screen, filter_name_char );
-    fadeout( virbuff, pal );
+    if ( fade_out )
+        fadeout( virbuff, pal );
 }
 
 /**

--- a/SRC/MISCFUNC.H
+++ b/SRC/MISCFUNC.H
@@ -8,7 +8,7 @@
 
 #include "TYPES.H"
 
-void change_name( int num );
+void change_name( int num, bool fade_out = true );
 char *k_2_c( const i::Input& input );
 i::Input get_key( int x, int y );
 void clear_shit( int y );

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -568,6 +568,16 @@ int deathmatch_options()
     return(start);
 }
 
+// Open a name prompt for player 1 if user has not yet changed it
+void prompt_name_if_needed()
+{
+    if ( !strcmp( name1, "phucka" ) )
+    {
+        change_name( 1, false );
+        save_options();
+    }
+}
+
 void multiplayer_options()
 {
     int yoffs = ( 15*num_multip_options )  / 2, a, cnt = 0, selected = 0, quit = 0, oclock = 0;
@@ -653,6 +663,8 @@ void multiplayer_options()
                 {
                     if ( GAME_MODE == NETWORK )
                     {
+                        prompt_name_if_needed();
+
                         if ( deathmatch_options())
                         {
                             NETWORK_MODE = SERVER;
@@ -697,6 +709,7 @@ void multiplayer_options()
             }
             if ( selected == 1 )
             {
+                prompt_name_if_needed();
 
                 GAME_MODE = NETWORK;
                 NETWORK_MODE = CLIENT;

--- a/SRC/WRITE.CPP
+++ b/SRC/WRITE.CPP
@@ -55,12 +55,7 @@ void readline( int x, int y, int len, char *str, char *screen, bool (*filter_cha
                     str[strlen( str )] = key;
                 }
             }
-        if ( input == k::ESC )
-        {
-            str[0] = 0;
-            done = 1;
-        }
-        if ( input == k::ENTER )
+        if ( input == k::ESC || input == k::ENTER )
         {
             done = 1;
         }


### PR DESCRIPTION
Resolves #169 
Resolves #142 

Prompt player name if starting online game (as a host or as a client) if player 1 still has the default name.

Fix issue where player is left with empty name if pressing ESC in name prompt.