### PR TITLE
Online game name feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ New features:
 
 - Number of players on a server is shown on server list
 
+- Online game name can be set in multiplayer options. It defaults to
+  player name.
+
 Bugfixes:
 
 - Many memory leaks and buffer overflows have been fixed.
@@ -246,6 +249,7 @@ Releases
     - Increased network code execution frequency
     - Show number of players on server list (native port only for now)
     - Reduced keep-alive messages
+    - Add game name option to multiplayer options
 - Fixed a memory leak in sound resampling
 - Fixed minor buffer overflow with sprite loading
 - Fixed a local deathmatch crash if playing with enemies

--- a/SRC/DEFINES.H
+++ b/SRC/DEFINES.H
@@ -59,9 +59,9 @@
 #define num_game_options 4
 #define num_sound_options 3
 #if defined (__EMSCRIPTEN__)
-#define num_deathmatch_options 5
+#define num_deathmatch_options 6
 #else
-#define num_deathmatch_options 4
+#define num_deathmatch_options 5
 #endif
 #define num_multip_options 7
 #define DIFF_K 10

--- a/SRC/GAME.CPP
+++ b/SRC/GAME.CPP
@@ -20,7 +20,6 @@
 int ipxofs[MAX_PLAYERS];
 char ipxstream[MAX_PLAYERS][MAXDATASIZE];
 struct nodeaddr serveraddr;
-char servername[10];
 struct packet *snd, *rec[RECEIVERS];
 
 const size_t effect_packet_divider = 4;
@@ -1471,7 +1470,9 @@ void setup_ipx()
             error("Couldn't connect to lobby\n");
         }
 #endif
-        strcpy( servername, name1 );
+        if (!strcmp( "", servername ))
+            strcpy( servername, name1 );
+
         serveraddr.node = 0;
         if ( tk_port::net::create_server( servername, MAX_PLAYERS, port
 #if defined(TK_PORT_EMCC)

--- a/SRC/GLOBVAR.CPP
+++ b/SRC/GLOBVAR.CPP
@@ -68,6 +68,7 @@ char enemyspr6[1160*232];
 char enemyspr7[1160*232];
 char minespr[7*7];
 char name1[MAX_NAME_LENGTH], name2[MAX_NAME_LENGTH];
+char servername[MAX_NAME_LENGTH] = "";
 char client_password[MAX_PASSWORD_LENGTH] = "";
 char server_password[MAX_PASSWORD_LENGTH] = "";
 char trans_table[256][256];
@@ -422,6 +423,7 @@ char opt_text[num_options][50] =
 char deathmatch_opt_text[num_deathmatch_options][50] =
 {
     "start game",
+    "game name",
     "moving",
     "enemies",
 #if defined(TK_PORT_EMCC)

--- a/SRC/GLOBVAR.H
+++ b/SRC/GLOBVAR.H
@@ -30,6 +30,7 @@ extern char wallspr[], floorspr2[], rambospr[], bodypartspr[], effectspr[];
 extern char pal[], picture[], warespr[], enemyspr0[], enemyspr1[], enemyspr2[];
 extern char enemyspr3[], enemyspr4[], enemyspr5[], enemyspr6[], enemyspr7[], minespr[];
 extern char name1[MAX_NAME_LENGTH], name2[MAX_NAME_LENGTH];
+extern char servername[MAX_NAME_LENGTH];
 extern char client_password[MAX_PASSWORD_LENGTH];
 extern char server_password[MAX_PASSWORD_LENGTH];
 extern char trans_table[256][256];

--- a/SRC/MISCFUNC.CPP
+++ b/SRC/MISCFUNC.CPP
@@ -60,6 +60,22 @@ void change_name( int num, bool fade_out )
         fadeout( virbuff, pal );
 }
 
+void change_game_name()
+{
+    const char* const title = "enter game name";
+    int x;
+    fadeout(virbuff, pal);
+    load_efp("EFPS/COOL.EFP", picture, 0);
+    FONT_NUM = 0;
+    x = 160 - (str_length(title) / 2);
+    draw_box1(x - 10, 75, 320 - x + 10, 125, 5);
+    memcpy(virbuff, picture, 64000);
+    writefonts2(x, 85, title, 1);
+    fadein(virbuff, pal);
+    i::clear_stack();
+    readline(x, 100, MAX_NAME_LENGTH, servername, screen, filter_name_char);
+}
+
 /**
  * Convert an Input object into a string representing it.
  *

--- a/SRC/MISCFUNC.H
+++ b/SRC/MISCFUNC.H
@@ -9,6 +9,7 @@
 #include "TYPES.H"
 
 void change_name( int num, bool fade_out = true );
+void change_game_name();
 char *k_2_c( const i::Input& input );
 i::Input get_key( int x, int y );
 void clear_shit( int y );

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -521,9 +521,7 @@ int deathmatch_options()
 {
     int selected = 0;
 
-#if defined(TK_PORT_EMCC)
     begin:
-#endif
 
     int start=0;
     int yoffs = ( 15*num_deathmatch_options )  / 2, a, cnt = 0, quit = 0, oclock = 0;
@@ -534,8 +532,8 @@ int deathmatch_options()
     {
         memcpy( virbuff, picture, 64000 );
         if ( DEATH_MATCH_SPEED == 2 )
-             strcpy(deathmatch_opt_text[1],"normal moving");
-        else strcpy(deathmatch_opt_text[1],"fast moving");
+             strcpy(deathmatch_opt_text[2],"normal moving");
+        else strcpy(deathmatch_opt_text[2],"fast moving");
 
         // Enemies are not supported over network
         if ( GAME_MODE == NETWORK )
@@ -544,13 +542,13 @@ int deathmatch_options()
         }
 
         if ( ENEMIES_ON_GAME )
-             strcpy(deathmatch_opt_text[2],"enemies on" );
-        else strcpy(deathmatch_opt_text[2],"enemies off" );
+             strcpy(deathmatch_opt_text[3],"enemies on" );
+        else strcpy(deathmatch_opt_text[3],"enemies off" );
         for ( a = 0; a < num_deathmatch_options; a ++  )
         {
             FONT_NUM = a == selected ? 0 : 2;
 #if defined(TK_PORT_EMCC)
-            if (a == 3)
+            if (a == 4)
                 server_password_field( a, yoffs );
             else
 #endif
@@ -577,14 +575,22 @@ int deathmatch_options()
         if ( i::state(k::ARROW_UP) )
         {
             selected --;
-            if ( selected == 3 && GAME_MODE != NETWORK ) selected --;
+            if ((
+#if defined(TK_PORT_EMCC)
+              selected == 4 ||
+#endif
+              selected == 1) && GAME_MODE != NETWORK ) selected --;
             if ( selected < 0 ) selected = num_deathmatch_options - 1;
             i::clear(k::ARROW_UP);
         }
         if ( i::state(k::ARROW_DOWN) )
         {
             selected ++;
-            if ( selected == 3 && GAME_MODE != NETWORK ) selected ++;
+            if ((
+#if defined(TK_PORT_EMCC)
+              selected == 4 ||
+#endif
+              selected == 1) && GAME_MODE != NETWORK ) selected ++;
             if ( selected >= num_deathmatch_options ) selected = 0;
             i::clear(k::ARROW_DOWN);
         }
@@ -592,10 +598,11 @@ int deathmatch_options()
         {
             i::clear(k::ENTER);
             if ( selected == 0 ) { quit = 1;start = 1;}
-            if ( selected == 1 ) DEATH_MATCH_SPEED = DEATH_MATCH_SPEED == 2 ? 3 : 2;
-            if ( selected == 2 ) ENEMIES_ON_GAME = GAME_MODE == NETWORK || ENEMIES_ON_GAME ? 0 : 1;
+            if ( selected == 1 ) { change_game_name(); goto begin; }
+            if ( selected == 2 ) DEATH_MATCH_SPEED = DEATH_MATCH_SPEED == 2 ? 3 : 2;
+            if ( selected == 3 ) ENEMIES_ON_GAME = GAME_MODE == NETWORK || ENEMIES_ON_GAME ? 0 : 1;
 #if defined(TK_PORT_EMCC)
-            if ( selected == 3 )
+            if ( selected == 4 )
             {
                 if ( GAME_MODE == NETWORK ) prompt_password(server_password);
                 goto begin;

--- a/SRC/OPTIONS.CPP
+++ b/SRC/OPTIONS.CPP
@@ -580,6 +580,7 @@ int deathmatch_options()
               selected == 4 ||
 #endif
               selected == 1) && GAME_MODE != NETWORK ) selected --;
+            if ( selected == 3 && GAME_MODE == NETWORK ) selected --;
             if ( selected < 0 ) selected = num_deathmatch_options - 1;
             i::clear(k::ARROW_UP);
         }
@@ -591,6 +592,7 @@ int deathmatch_options()
               selected == 4 ||
 #endif
               selected == 1) && GAME_MODE != NETWORK ) selected ++;
+            if ( selected == 3 && GAME_MODE == NETWORK ) selected ++;
             if ( selected >= num_deathmatch_options ) selected = 0;
             i::clear(k::ARROW_DOWN);
         }


### PR DESCRIPTION
Fixes #187 

Allow setting a game name for online games. Option is skipped for Split Screen games as is Password option.

![kuva](https://user-images.githubusercontent.com/24453333/97808081-4e8fec00-1c6d-11eb-870b-04e555525cf5.png)
