### PR TITLE
WebRTC: Fix host often crashing when client disconnects

### DIFF
--- a/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
+++ b/SRC/NET/TRANSPORT/WEBRTC/TRANSPORT.JS
@@ -455,7 +455,11 @@ const libraryWEBRTC = {
     for (let i = 0; i < bufferSize; i++) {
       view[i] = getValue(buffer + i, 'i8');
     }
-    peer.dataChannel.send(message);
+    try {
+      peer.dataChannel.send(message);
+    } catch (_err) {
+      return -2;
+    }
     return bufferSize;
   },
 


### PR DESCRIPTION
Catch errors if sending message via data channel fails for any reason (e.g. user just disconnected). The disconnect seems to be correctly propagated after that.